### PR TITLE
feat(injection): add intelligent tiered token optimization 

### DIFF
--- a/cmd/floop/stats.go
+++ b/cmd/floop/stats.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/nvandessel/feedback-loop/internal/learning"
+	"github.com/nvandessel/feedback-loop/internal/store"
+	"github.com/spf13/cobra"
+)
+
+func newStatsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stats",
+		Short: "Show behavior usage statistics",
+		Long: `Display usage statistics for learned behaviors.
+
+Shows activation counts, follow rates, and ranking scores to help
+understand which behaviors are most valuable and which may need review.
+
+Examples:
+  floop stats              # Show all stats
+  floop stats --top 10     # Show top 10 by usage
+  floop stats --sort score # Sort by ranking score`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, _ := cmd.Flags().GetString("root")
+			jsonOut, _ := cmd.Flags().GetBool("json")
+			topN, _ := cmd.Flags().GetInt("top")
+			sortBy, _ := cmd.Flags().GetString("sort")
+			scope, _ := cmd.Flags().GetString("scope")
+
+			// Parse scope
+			storeScope := store.ScopeLocal
+			switch scope {
+			case "global":
+				storeScope = store.ScopeGlobal
+			case "both":
+				storeScope = store.ScopeBoth
+			}
+
+			// Open graph store
+			graphStore, err := store.NewMultiGraphStore(root, storeScope)
+			if err != nil {
+				return fmt.Errorf("failed to open graph store: %w", err)
+			}
+			defer graphStore.Close()
+
+			ctx := context.Background()
+
+			// Query all behaviors
+			nodes, err := graphStore.QueryNodes(ctx, map[string]interface{}{"kind": "behavior"})
+			if err != nil {
+				return fmt.Errorf("failed to query behaviors: %w", err)
+			}
+
+			if len(nodes) == 0 {
+				if jsonOut {
+					json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+						"behaviors": []interface{}{},
+						"summary":   map[string]int{},
+					})
+				} else {
+					fmt.Println("No behaviors found.")
+				}
+				return nil
+			}
+
+			// Convert to behaviors and calculate stats
+			type BehaviorStats struct {
+				ID              string  `json:"id"`
+				Name            string  `json:"name"`
+				Kind            string  `json:"kind"`
+				Confidence      float64 `json:"confidence"`
+				Priority        int     `json:"priority"`
+				TimesActivated  int     `json:"times_activated"`
+				TimesFollowed   int     `json:"times_followed"`
+				TimesConfirmed  int     `json:"times_confirmed"`
+				TimesOverridden int     `json:"times_overridden"`
+				FollowRate      float64 `json:"follow_rate"`
+				HasSummary      bool    `json:"has_summary"`
+			}
+
+			stats := make([]BehaviorStats, 0, len(nodes))
+			var totalActivations, totalFollowed, totalConfirmed, totalOverridden int
+			kindCounts := make(map[string]int)
+
+			for _, node := range nodes {
+				behavior := learning.NodeToBehavior(node)
+
+				followRate := 0.0
+				if behavior.Stats.TimesActivated > 0 {
+					positiveSignals := behavior.Stats.TimesFollowed + behavior.Stats.TimesConfirmed
+					followRate = float64(positiveSignals) / float64(behavior.Stats.TimesActivated)
+				}
+
+				stats = append(stats, BehaviorStats{
+					ID:              behavior.ID,
+					Name:            behavior.Name,
+					Kind:            string(behavior.Kind),
+					Confidence:      behavior.Confidence,
+					Priority:        behavior.Priority,
+					TimesActivated:  behavior.Stats.TimesActivated,
+					TimesFollowed:   behavior.Stats.TimesFollowed,
+					TimesConfirmed:  behavior.Stats.TimesConfirmed,
+					TimesOverridden: behavior.Stats.TimesOverridden,
+					FollowRate:      followRate,
+					HasSummary:      behavior.Content.Summary != "",
+				})
+
+				totalActivations += behavior.Stats.TimesActivated
+				totalFollowed += behavior.Stats.TimesFollowed
+				totalConfirmed += behavior.Stats.TimesConfirmed
+				totalOverridden += behavior.Stats.TimesOverridden
+				kindCounts[string(behavior.Kind)]++
+			}
+
+			// Sort by specified field
+			switch sortBy {
+			case "activations", "activated":
+				sort.Slice(stats, func(i, j int) bool {
+					return stats[i].TimesActivated > stats[j].TimesActivated
+				})
+			case "followed":
+				sort.Slice(stats, func(i, j int) bool {
+					return stats[i].TimesFollowed > stats[j].TimesFollowed
+				})
+			case "rate", "follow_rate":
+				sort.Slice(stats, func(i, j int) bool {
+					return stats[i].FollowRate > stats[j].FollowRate
+				})
+			case "confidence":
+				sort.Slice(stats, func(i, j int) bool {
+					return stats[i].Confidence > stats[j].Confidence
+				})
+			case "priority":
+				sort.Slice(stats, func(i, j int) bool {
+					return stats[i].Priority > stats[j].Priority
+				})
+			default: // score (combined)
+				sort.Slice(stats, func(i, j int) bool {
+					scoreI := stats[i].Confidence * stats[i].FollowRate * float64(stats[i].Priority+1)
+					scoreJ := stats[j].Confidence * stats[j].FollowRate * float64(stats[j].Priority+1)
+					return scoreI > scoreJ
+				})
+			}
+
+			// Apply top N limit
+			if topN > 0 && topN < len(stats) {
+				stats = stats[:topN]
+			}
+
+			// Build summary
+			summary := map[string]interface{}{
+				"total_behaviors":   len(nodes),
+				"total_activations": totalActivations,
+				"total_followed":    totalFollowed,
+				"total_confirmed":   totalConfirmed,
+				"total_overridden":  totalOverridden,
+				"by_kind":           kindCounts,
+			}
+
+			// Count summaries
+			withSummary := 0
+			for _, s := range stats {
+				if s.HasSummary {
+					withSummary++
+				}
+			}
+			summary["with_summary"] = withSummary
+
+			// Output
+			if jsonOut {
+				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+					"behaviors": stats,
+					"summary":   summary,
+				})
+			} else {
+				fmt.Printf("Behavior Statistics\n")
+				fmt.Printf("===================\n\n")
+
+				fmt.Printf("Summary:\n")
+				fmt.Printf("  Total behaviors:   %d\n", len(nodes))
+				fmt.Printf("  With summaries:    %d\n", withSummary)
+				fmt.Printf("  Total activations: %d\n", totalActivations)
+				fmt.Printf("  Total followed:    %d\n", totalFollowed)
+				fmt.Printf("  Total confirmed:   %d\n", totalConfirmed)
+				fmt.Printf("  Total overridden:  %d\n", totalOverridden)
+				fmt.Printf("\n")
+
+				fmt.Printf("By kind:\n")
+				for kind, count := range kindCounts {
+					fmt.Printf("  %s: %d\n", kind, count)
+				}
+				fmt.Printf("\n")
+
+				if len(stats) > 0 {
+					fmt.Printf("Behaviors (sorted by %s):\n\n", sortBy)
+					fmt.Printf("%-8s %-30s %-12s %6s %6s %6s %8s\n",
+						"ID", "Name", "Kind", "Act", "Fol", "Conf", "Rate")
+					fmt.Println(repeatChar('-', 86))
+
+					for _, s := range stats {
+						shortID := s.ID
+						if len(shortID) > 8 {
+							shortID = shortID[:8]
+						}
+						name := s.Name
+						if len(name) > 30 {
+							name = name[:27] + "..."
+						}
+						kind := s.Kind
+						if len(kind) > 12 {
+							kind = kind[:12]
+						}
+
+						fmt.Printf("%-8s %-30s %-12s %6d %6d %6d %7.0f%%\n",
+							shortID, name, kind,
+							s.TimesActivated, s.TimesFollowed, s.TimesConfirmed,
+							s.FollowRate*100)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Int("top", 0, "Show only top N behaviors")
+	cmd.Flags().String("sort", "score", "Sort by: score, activations, followed, rate, confidence, priority")
+	cmd.Flags().String("scope", "local", "Scope: local, global, or both")
+
+	return cmd
+}
+
+func repeatChar(c rune, n int) string {
+	result := make([]rune, n)
+	for i := range result {
+		result[i] = c
+	}
+	return string(result)
+}

--- a/cmd/floop/summarize.go
+++ b/cmd/floop/summarize.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/nvandessel/feedback-loop/internal/learning"
+	"github.com/nvandessel/feedback-loop/internal/store"
+	"github.com/nvandessel/feedback-loop/internal/summarization"
+	"github.com/spf13/cobra"
+)
+
+func newSummarizeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "summarize [behavior-id]",
+		Short: "Generate or regenerate summaries for behaviors",
+		Long: `Generate compressed summaries for behaviors to optimize token usage.
+
+Summaries are used in tiered injection when the full behavior content
+would exceed the token budget. Each summary is ~60 characters.
+
+Examples:
+  floop summarize abc123      # Generate summary for specific behavior
+  floop summarize --all       # Generate summaries for all behaviors
+  floop summarize --missing   # Only generate for behaviors without summaries`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, _ := cmd.Flags().GetString("root")
+			jsonOut, _ := cmd.Flags().GetBool("json")
+			allBehaviors, _ := cmd.Flags().GetBool("all")
+			missingOnly, _ := cmd.Flags().GetBool("missing")
+			scope, _ := cmd.Flags().GetString("scope")
+
+			// Validate flags
+			if len(args) == 0 && !allBehaviors && !missingOnly {
+				return fmt.Errorf("specify a behavior ID or use --all/--missing")
+			}
+
+			// Parse scope
+			storeScope := store.ScopeLocal
+			switch scope {
+			case "global":
+				storeScope = store.ScopeGlobal
+			case "both":
+				storeScope = store.ScopeBoth
+			}
+
+			// Open graph store
+			graphStore, err := store.NewMultiGraphStore(root, storeScope)
+			if err != nil {
+				return fmt.Errorf("failed to open graph store: %w", err)
+			}
+			defer graphStore.Close()
+
+			ctx := context.Background()
+
+			// Create summarizer
+			summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+
+			// Results tracking
+			var results []summaryResult
+
+			if len(args) > 0 {
+				// Process single behavior
+				behaviorID := args[0]
+				res, err := summarizeBehavior(ctx, graphStore, summarizer, behaviorID)
+				if err != nil {
+					return err
+				}
+				results = append(results, res)
+			} else {
+				// Process all or missing
+				nodes, err := graphStore.QueryNodes(ctx, map[string]interface{}{"kind": "behavior"})
+				if err != nil {
+					return fmt.Errorf("failed to query behaviors: %w", err)
+				}
+
+				for _, node := range nodes {
+					behavior := learning.NodeToBehavior(node)
+
+					// Skip if missingOnly and summary exists
+					if missingOnly && behavior.Content.Summary != "" {
+						continue
+					}
+
+					res, err := summarizeBehavior(ctx, graphStore, summarizer, behavior.ID)
+					if err != nil {
+						res = summaryResult{
+							BehaviorID: behavior.ID,
+							Name:       behavior.Name,
+							Error:      err.Error(),
+						}
+					}
+					results = append(results, res)
+				}
+			}
+
+			// Sync changes
+			if err := graphStore.Sync(ctx); err != nil {
+				return fmt.Errorf("failed to sync store: %w", err)
+			}
+
+			// Output results
+			if jsonOut {
+				json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+					"results": results,
+					"count":   len(results),
+					"updated": countUpdated(results),
+				})
+			} else {
+				if len(results) == 0 {
+					fmt.Println("No behaviors to summarize.")
+					return nil
+				}
+
+				fmt.Printf("Summarized %d behavior(s):\n\n", len(results))
+				for _, r := range results {
+					shortID := r.BehaviorID
+					if len(shortID) > 8 {
+						shortID = shortID[:8]
+					}
+					if r.Error != "" {
+						fmt.Printf("  %s: ERROR - %s\n", shortID, r.Error)
+					} else if r.Updated {
+						fmt.Printf("  %s: %s\n", shortID, r.Summary)
+					} else {
+						fmt.Printf("  %s: (unchanged) %s\n", shortID, r.Summary)
+					}
+				}
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().Bool("all", false, "Generate summaries for all behaviors")
+	cmd.Flags().Bool("missing", false, "Only generate for behaviors without summaries")
+	cmd.Flags().String("scope", "local", "Scope: local, global, or both")
+
+	return cmd
+}
+
+// summaryResult holds the result of summarizing a behavior
+type summaryResult struct {
+	BehaviorID string `json:"behavior_id"`
+	Name       string `json:"name"`
+	Summary    string `json:"summary"`
+	Updated    bool   `json:"updated"`
+	Error      string `json:"error,omitempty"`
+}
+
+// summarizeBehavior generates a summary for a single behavior
+func summarizeBehavior(ctx context.Context, graphStore store.GraphStore, summarizer summarization.Summarizer, behaviorID string) (summaryResult, error) {
+	// Query for the behavior
+	nodes, err := graphStore.QueryNodes(ctx, map[string]interface{}{
+		"kind": "behavior",
+		"id":   behaviorID,
+	})
+	if err != nil {
+		return summaryResult{BehaviorID: behaviorID, Error: err.Error()}, err
+	}
+	if len(nodes) == 0 {
+		return summaryResult{BehaviorID: behaviorID, Error: "not found"}, fmt.Errorf("behavior not found: %s", behaviorID)
+	}
+
+	behavior := learning.NodeToBehavior(nodes[0])
+	oldSummary := behavior.Content.Summary
+
+	// Generate summary
+	summary, err := summarizer.Summarize(&behavior)
+	if err != nil {
+		return summaryResult{BehaviorID: behaviorID, Name: behavior.Name, Error: err.Error()}, err
+	}
+
+	// Check if changed
+	updated := summary != oldSummary
+	if updated {
+		// Update the behavior node
+		node := nodes[0]
+		if content, ok := node.Content["content"].(map[string]interface{}); ok {
+			content["summary"] = summary
+		} else {
+			node.Content["content"] = map[string]interface{}{
+				"canonical": behavior.Content.Canonical,
+				"summary":   summary,
+			}
+		}
+
+		if err := graphStore.UpdateNode(ctx, node); err != nil {
+			return summaryResult{BehaviorID: behaviorID, Name: behavior.Name, Error: err.Error()}, err
+		}
+	}
+
+	return summaryResult{
+		BehaviorID: behaviorID,
+		Name:       behavior.Name,
+		Summary:    summary,
+		Updated:    updated,
+	}, nil
+}
+
+func countUpdated(results []summaryResult) int {
+	count := 0
+	for _, r := range results {
+		if r.Updated {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/assembly/optimize.go
+++ b/internal/assembly/optimize.go
@@ -207,3 +207,148 @@ func (o *Optimizer) compareImportance(bi, bj models.Behavior) bool {
 	// Higher confidence
 	return bi.Confidence > bj.Confidence
 }
+
+// OptimizeWithTiers creates a tiered injection plan using ranking, scoring, and summarization
+// This is the main entry point for intelligent token optimization with tiering
+func (o *Optimizer) OptimizeWithTiers(behaviors []models.Behavior, ctx *models.ContextSnapshot) *models.InjectionPlan {
+	// Import the tiering package's QuickAssign for a simple implementation
+	// For more control, callers should use the tiering package directly
+	return optimizeWithTiersInternal(behaviors, ctx, o.maxTokens)
+}
+
+// optimizeWithTiersInternal implements tiered optimization without circular imports
+// This is a simplified version; for full control use the tiering package
+func optimizeWithTiersInternal(behaviors []models.Behavior, ctx *models.ContextSnapshot, budget int) *models.InjectionPlan {
+	if len(behaviors) == 0 {
+		return &models.InjectionPlan{
+			TokenBudget: budget,
+		}
+	}
+
+	// Sort by importance (constraints first, then priority/confidence)
+	sorted := make([]models.Behavior, len(behaviors))
+	copy(sorted, behaviors)
+	sortBehaviorsByImportance(sorted)
+
+	// Budget allocation: 60% full, 30% summary, 10% overhead
+	fullBudget := int(float64(budget) * 0.60)
+	summaryBudget := int(float64(budget) * 0.30)
+
+	plan := &models.InjectionPlan{
+		TokenBudget:         budget,
+		FullBehaviors:       make([]models.InjectedBehavior, 0),
+		SummarizedBehaviors: make([]models.InjectedBehavior, 0),
+		OmittedBehaviors:    make([]models.InjectedBehavior, 0),
+	}
+
+	fullTokensUsed := 0
+	summaryTokensUsed := 0
+
+	for i := range sorted {
+		b := &sorted[i]
+		tokenCost := estimateTokens(b.Content.Canonical) + 5
+
+		// Constraints always get full tier
+		if b.Kind == models.BehaviorKindConstraint {
+			injected := models.InjectedBehavior{
+				Behavior:  b,
+				Tier:      models.TierFull,
+				Content:   b.Content.Canonical,
+				TokenCost: tokenCost,
+				Score:     float64(b.Priority) * b.Confidence,
+			}
+			plan.FullBehaviors = append(plan.FullBehaviors, injected)
+			fullTokensUsed += tokenCost
+			continue
+		}
+
+		// Try full tier
+		if fullTokensUsed+tokenCost <= fullBudget {
+			injected := models.InjectedBehavior{
+				Behavior:  b,
+				Tier:      models.TierFull,
+				Content:   b.Content.Canonical,
+				TokenCost: tokenCost,
+				Score:     float64(b.Priority) * b.Confidence,
+			}
+			plan.FullBehaviors = append(plan.FullBehaviors, injected)
+			fullTokensUsed += tokenCost
+		} else {
+			// Try summary tier
+			summary := getSummaryContent(b)
+			summaryTokenCost := estimateTokens(summary) + 3
+
+			if summaryTokensUsed+summaryTokenCost <= summaryBudget {
+				injected := models.InjectedBehavior{
+					Behavior:  b,
+					Tier:      models.TierSummary,
+					Content:   summary,
+					TokenCost: summaryTokenCost,
+					Score:     float64(b.Priority) * b.Confidence,
+				}
+				plan.SummarizedBehaviors = append(plan.SummarizedBehaviors, injected)
+				summaryTokensUsed += summaryTokenCost
+			} else {
+				// Omit
+				injected := models.InjectedBehavior{
+					Behavior:  b,
+					Tier:      models.TierOmitted,
+					Content:   "",
+					TokenCost: 0,
+					Score:     float64(b.Priority) * b.Confidence,
+				}
+				plan.OmittedBehaviors = append(plan.OmittedBehaviors, injected)
+			}
+		}
+	}
+
+	plan.TotalTokens = fullTokensUsed + summaryTokensUsed
+
+	return plan
+}
+
+// sortBehaviorsByImportance sorts behaviors for tiered optimization
+func sortBehaviorsByImportance(behaviors []models.Behavior) {
+	sort.Slice(behaviors, func(i, j int) bool {
+		bi, bj := behaviors[i], behaviors[j]
+
+		// Constraints first
+		if bi.Kind == models.BehaviorKindConstraint && bj.Kind != models.BehaviorKindConstraint {
+			return true
+		}
+		if bj.Kind == models.BehaviorKindConstraint && bi.Kind != models.BehaviorKindConstraint {
+			return false
+		}
+
+		// Higher priority
+		if bi.Priority != bj.Priority {
+			return bi.Priority > bj.Priority
+		}
+
+		// Higher confidence
+		return bi.Confidence > bj.Confidence
+	})
+}
+
+// getSummaryContent returns summary content for a behavior
+func getSummaryContent(b *models.Behavior) string {
+	if b.Content.Summary != "" {
+		return b.Content.Summary
+	}
+
+	// Fallback: truncate canonical
+	canonical := b.Content.Canonical
+	if len(canonical) > 60 {
+		// Try to truncate at word boundary
+		truncated := canonical[:57]
+		lastSpace := len(truncated) - 1
+		for lastSpace > 30 && truncated[lastSpace] != ' ' {
+			lastSpace--
+		}
+		if lastSpace > 30 {
+			truncated = truncated[:lastSpace]
+		}
+		return truncated + "..."
+	}
+	return canonical
+}

--- a/internal/models/behavior.go
+++ b/internal/models/behavior.go
@@ -22,6 +22,13 @@ type BehaviorContent struct {
 	// Expanded is the full prose version with examples and rationale
 	Expanded string `json:"expanded,omitempty" yaml:"expanded,omitempty"`
 
+	// Summary is an ultra-compressed single-line reminder (~60 chars)
+	// Used for tiered injection when token budget is constrained
+	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
+
+	// Tags are keyword tags for clustering and categorization
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
+
 	// Structured holds key-value data when the behavior has clear structure
 	// e.g., {"prefer": "pathlib.Path", "avoid": "os.path"}
 	Structured map[string]interface{} `json:"structured,omitempty" yaml:"structured,omitempty"`
@@ -73,7 +80,9 @@ type BehaviorStats struct {
 	TimesActivated  int        `json:"times_activated" yaml:"times_activated"`
 	TimesFollowed   int        `json:"times_followed" yaml:"times_followed"`
 	TimesOverridden int        `json:"times_overridden" yaml:"times_overridden"`
+	TimesConfirmed  int        `json:"times_confirmed" yaml:"times_confirmed"` // Positive signal when behavior was followed
 	LastActivated   *time.Time `json:"last_activated,omitempty" yaml:"last_activated,omitempty"`
+	LastConfirmed   *time.Time `json:"last_confirmed,omitempty" yaml:"last_confirmed,omitempty"` // Last time behavior was positively confirmed
 	CreatedAt       time.Time  `json:"created_at" yaml:"created_at"`
 	UpdatedAt       time.Time  `json:"updated_at" yaml:"updated_at"`
 }

--- a/internal/models/injection.go
+++ b/internal/models/injection.go
@@ -1,0 +1,90 @@
+package models
+
+// InjectionTier represents the level of detail for an injected behavior
+type InjectionTier int
+
+const (
+	// TierFull includes the full canonical content
+	TierFull InjectionTier = iota
+	// TierSummary includes only a one-line summary
+	TierSummary
+	// TierOmitted means the behavior is referenced but not included
+	TierOmitted
+)
+
+// String returns a string representation of the tier
+func (t InjectionTier) String() string {
+	switch t {
+	case TierFull:
+		return "full"
+	case TierSummary:
+		return "summary"
+	case TierOmitted:
+		return "omitted"
+	default:
+		return "unknown"
+	}
+}
+
+// InjectedBehavior represents a behavior prepared for injection with tier info
+type InjectedBehavior struct {
+	// Behavior is the original behavior being injected
+	Behavior *Behavior `json:"behavior"`
+
+	// Tier indicates the level of detail included
+	Tier InjectionTier `json:"tier"`
+
+	// Content is the actual content to inject (varies by tier)
+	Content string `json:"content"`
+
+	// TokenCost is the estimated token cost for this injection
+	TokenCost int `json:"token_cost"`
+
+	// Score is the ranking score used for prioritization
+	Score float64 `json:"score"`
+}
+
+// InjectionPlan represents a complete plan for injecting behaviors
+type InjectionPlan struct {
+	// FullBehaviors are behaviors included at full detail
+	FullBehaviors []InjectedBehavior `json:"full_behaviors"`
+
+	// SummarizedBehaviors are behaviors included as summaries only
+	SummarizedBehaviors []InjectedBehavior `json:"summarized_behaviors"`
+
+	// OmittedBehaviors are behaviors referenced but not included
+	OmittedBehaviors []InjectedBehavior `json:"omitted_behaviors"`
+
+	// TotalTokens is the total token cost of the plan
+	TotalTokens int `json:"total_tokens"`
+
+	// TokenBudget is the budget this plan was optimized for
+	TokenBudget int `json:"token_budget"`
+}
+
+// AllBehaviors returns all behaviors in the plan, regardless of tier
+func (p *InjectionPlan) AllBehaviors() []InjectedBehavior {
+	all := make([]InjectedBehavior, 0, len(p.FullBehaviors)+len(p.SummarizedBehaviors)+len(p.OmittedBehaviors))
+	all = append(all, p.FullBehaviors...)
+	all = append(all, p.SummarizedBehaviors...)
+	all = append(all, p.OmittedBehaviors...)
+	return all
+}
+
+// IncludedBehaviors returns all behaviors that will be injected (full + summarized)
+func (p *InjectionPlan) IncludedBehaviors() []InjectedBehavior {
+	included := make([]InjectedBehavior, 0, len(p.FullBehaviors)+len(p.SummarizedBehaviors))
+	included = append(included, p.FullBehaviors...)
+	included = append(included, p.SummarizedBehaviors...)
+	return included
+}
+
+// BehaviorCount returns the total number of behaviors in the plan
+func (p *InjectionPlan) BehaviorCount() int {
+	return len(p.FullBehaviors) + len(p.SummarizedBehaviors) + len(p.OmittedBehaviors)
+}
+
+// IncludedCount returns the number of behaviors that will be injected
+func (p *InjectionPlan) IncludedCount() int {
+	return len(p.FullBehaviors) + len(p.SummarizedBehaviors)
+}

--- a/internal/ranking/decay.go
+++ b/internal/ranking/decay.go
@@ -1,0 +1,84 @@
+package ranking
+
+import (
+	"math"
+	"time"
+)
+
+// ExponentialDecay calculates a decay score based on time elapsed
+// Returns a value between 0 and 1, where 1 means the time is now
+// and 0 approaches as time goes to infinity.
+// The halfLife parameter determines how quickly the score decays.
+func ExponentialDecay(t time.Time, halfLife time.Duration) float64 {
+	if t.IsZero() {
+		return 0.0
+	}
+
+	elapsed := time.Since(t)
+	if elapsed <= 0 {
+		return 1.0
+	}
+
+	// Using natural decay: score = e^(-lambda * t)
+	// where lambda = ln(2) / halfLife
+	lambda := math.Ln2 / float64(halfLife)
+	score := math.Exp(-lambda * float64(elapsed))
+
+	return score
+}
+
+// LinearDecay calculates a linear decay score based on time elapsed
+// Returns a value between 0 and 1, where 1 means the time is now
+// and 0 means the maxAge has been reached or exceeded.
+func LinearDecay(t time.Time, maxAge time.Duration) float64 {
+	if t.IsZero() {
+		return 0.0
+	}
+
+	elapsed := time.Since(t)
+	if elapsed <= 0 {
+		return 1.0
+	}
+
+	if elapsed >= maxAge {
+		return 0.0
+	}
+
+	return 1.0 - float64(elapsed)/float64(maxAge)
+}
+
+// StepDecay returns discrete decay levels based on time thresholds
+// Returns 1.0 for recent, 0.5 for medium, 0.25 for old, 0.0 for very old
+func StepDecay(t time.Time, recent, medium, old time.Duration) float64 {
+	if t.IsZero() {
+		return 0.0
+	}
+
+	elapsed := time.Since(t)
+	if elapsed <= 0 {
+		return 1.0
+	}
+
+	switch {
+	case elapsed < recent:
+		return 1.0
+	case elapsed < medium:
+		return 0.75
+	case elapsed < old:
+		return 0.5
+	default:
+		return 0.25
+	}
+}
+
+// BoostedDecay combines exponential decay with a minimum floor
+// Ensures behaviors never decay below minScore, preserving long-term memory
+func BoostedDecay(t time.Time, halfLife time.Duration, minScore float64) float64 {
+	base := ExponentialDecay(t, halfLife)
+
+	// Apply floor
+	if base < minScore {
+		return minScore
+	}
+	return base
+}

--- a/internal/ranking/scorer.go
+++ b/internal/ranking/scorer.go
@@ -1,0 +1,276 @@
+package ranking
+
+import (
+	"time"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+)
+
+// ScorerConfig configures the relevance scorer
+type ScorerConfig struct {
+	// Weight for context match specificity (0.0-1.0)
+	ContextWeight float64
+
+	// Weight for usage signals (followed/activated ratio) (0.0-1.0)
+	UsageWeight float64
+
+	// Weight for recency (0.0-1.0)
+	RecencyWeight float64
+
+	// Weight for confidence score (0.0-1.0)
+	ConfidenceWeight float64
+
+	// Weight for priority and kind (0.0-1.0)
+	PriorityWeight float64
+
+	// RecencyHalfLife is the time after which recency score is halved
+	RecencyHalfLife time.Duration
+
+	// KindBoosts are score multipliers for behavior kinds
+	KindBoosts map[models.BehaviorKind]float64
+}
+
+// DefaultScorerConfig returns the default scoring configuration
+// Weights: Context 25%, Usage 25%, Recency 15%, Confidence 15%, Priority 20%
+func DefaultScorerConfig() ScorerConfig {
+	return ScorerConfig{
+		ContextWeight:    0.25,
+		UsageWeight:      0.25,
+		RecencyWeight:    0.15,
+		ConfidenceWeight: 0.15,
+		PriorityWeight:   0.20,
+		RecencyHalfLife:  7 * 24 * time.Hour, // 1 week
+		KindBoosts: map[models.BehaviorKind]float64{
+			models.BehaviorKindConstraint: 2.0, // Constraints are safety-critical
+			models.BehaviorKindDirective:  1.5,
+			models.BehaviorKindProcedure:  1.2,
+			models.BehaviorKindPreference: 1.0,
+		},
+	}
+}
+
+// RelevanceScorer calculates relevance scores for behaviors
+type RelevanceScorer struct {
+	config ScorerConfig
+}
+
+// NewRelevanceScorer creates a new relevance scorer with the given config
+func NewRelevanceScorer(config ScorerConfig) *RelevanceScorer {
+	// Validate and normalize weights
+	totalWeight := config.ContextWeight + config.UsageWeight + config.RecencyWeight +
+		config.ConfidenceWeight + config.PriorityWeight
+
+	if totalWeight > 0 && totalWeight != 1.0 {
+		// Normalize weights to sum to 1.0
+		config.ContextWeight /= totalWeight
+		config.UsageWeight /= totalWeight
+		config.RecencyWeight /= totalWeight
+		config.ConfidenceWeight /= totalWeight
+		config.PriorityWeight /= totalWeight
+	}
+
+	if config.RecencyHalfLife <= 0 {
+		config.RecencyHalfLife = 7 * 24 * time.Hour
+	}
+
+	if config.KindBoosts == nil {
+		config.KindBoosts = DefaultScorerConfig().KindBoosts
+	}
+
+	return &RelevanceScorer{config: config}
+}
+
+// ScoredBehavior represents a behavior with its calculated relevance score
+type ScoredBehavior struct {
+	Behavior *models.Behavior
+	Score    float64
+
+	// Component scores for debugging/transparency
+	ContextScore    float64
+	UsageScore      float64
+	RecencyScore    float64
+	ConfidenceScore float64
+	PriorityScore   float64
+	KindBoost       float64
+}
+
+// Score calculates the relevance score for a single behavior
+func (s *RelevanceScorer) Score(behavior *models.Behavior, ctx *models.ContextSnapshot) ScoredBehavior {
+	if behavior == nil {
+		return ScoredBehavior{}
+	}
+
+	scored := ScoredBehavior{
+		Behavior:        behavior,
+		ContextScore:    s.contextScore(behavior, ctx),
+		UsageScore:      s.usageScore(behavior),
+		RecencyScore:    s.recencyScore(behavior),
+		ConfidenceScore: s.confidenceScore(behavior),
+		PriorityScore:   s.priorityScore(behavior),
+		KindBoost:       s.kindBoost(behavior.Kind),
+	}
+
+	// Calculate weighted score
+	baseScore := scored.ContextScore*s.config.ContextWeight +
+		scored.UsageScore*s.config.UsageWeight +
+		scored.RecencyScore*s.config.RecencyWeight +
+		scored.ConfidenceScore*s.config.ConfidenceWeight +
+		scored.PriorityScore*s.config.PriorityWeight
+
+	// Apply kind boost
+	scored.Score = baseScore * scored.KindBoost
+
+	return scored
+}
+
+// ScoreBatch calculates relevance scores for multiple behaviors
+func (s *RelevanceScorer) ScoreBatch(behaviors []models.Behavior, ctx *models.ContextSnapshot) []ScoredBehavior {
+	results := make([]ScoredBehavior, len(behaviors))
+	for i := range behaviors {
+		results[i] = s.Score(&behaviors[i], ctx)
+	}
+	return results
+}
+
+// contextScore calculates how specifically the behavior matches the context
+func (s *RelevanceScorer) contextScore(behavior *models.Behavior, ctx *models.ContextSnapshot) float64 {
+	if behavior.When == nil || len(behavior.When) == 0 {
+		// Global behaviors (no when predicate) get a base score
+		return 0.5
+	}
+
+	// More specific predicates = higher score
+	// Count matching predicates
+	matches := 0
+	total := len(behavior.When)
+
+	for key := range behavior.When {
+		if ctx != nil && s.predicateMatches(key, ctx) {
+			matches++
+		}
+	}
+
+	if total == 0 {
+		return 0.5
+	}
+
+	// Specificity bonus: more predicates = more specific
+	specificityBonus := float64(total) * 0.1
+	if specificityBonus > 0.3 {
+		specificityBonus = 0.3
+	}
+
+	matchRatio := float64(matches) / float64(total)
+	score := matchRatio + specificityBonus
+
+	// Clamp to [0, 1]
+	if score > 1.0 {
+		score = 1.0
+	}
+	return score
+}
+
+// predicateMatches checks if a predicate key matches the context
+func (s *RelevanceScorer) predicateMatches(key string, ctx *models.ContextSnapshot) bool {
+	switch key {
+	case "file", "file_path":
+		return ctx.FilePath != ""
+	case "language":
+		return ctx.FileLanguage != ""
+	case "task":
+		return ctx.Task != ""
+	case "environment", "env":
+		return ctx.Environment != ""
+	case "repo", "repository":
+		return ctx.RepoRoot != ""
+	default:
+		// Check custom fields
+		if ctx.Custom != nil {
+			_, ok := ctx.Custom[key]
+			return ok
+		}
+		return false
+	}
+}
+
+// usageScore calculates score based on usage statistics
+func (s *RelevanceScorer) usageScore(behavior *models.Behavior) float64 {
+	stats := behavior.Stats
+
+	// Calculate followed/activated ratio
+	if stats.TimesActivated == 0 {
+		// New behavior, give it a fair chance
+		return 0.5
+	}
+
+	// TimesFollowed + TimesConfirmed = positive signals
+	positiveSignals := stats.TimesFollowed + stats.TimesConfirmed
+	totalActivations := stats.TimesActivated
+
+	ratio := float64(positiveSignals) / float64(totalActivations)
+
+	// Penalize behaviors that are frequently overridden
+	if stats.TimesOverridden > 0 {
+		overrideRatio := float64(stats.TimesOverridden) / float64(totalActivations)
+		ratio -= overrideRatio * 0.5 // 50% penalty for overrides
+	}
+
+	// Clamp to [0, 1]
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+
+	return ratio
+}
+
+// recencyScore calculates score based on how recently the behavior was used
+func (s *RelevanceScorer) recencyScore(behavior *models.Behavior) float64 {
+	// Use most recent of: LastActivated, LastConfirmed, UpdatedAt
+	var lastUsed time.Time
+
+	if behavior.Stats.LastConfirmed != nil && behavior.Stats.LastConfirmed.After(lastUsed) {
+		lastUsed = *behavior.Stats.LastConfirmed
+	}
+	if behavior.Stats.LastActivated != nil && behavior.Stats.LastActivated.After(lastUsed) {
+		lastUsed = *behavior.Stats.LastActivated
+	}
+	if behavior.Stats.UpdatedAt.After(lastUsed) {
+		lastUsed = behavior.Stats.UpdatedAt
+	}
+
+	// If no activity, use creation time
+	if lastUsed.IsZero() {
+		lastUsed = behavior.Stats.CreatedAt
+	}
+
+	return ExponentialDecay(lastUsed, s.config.RecencyHalfLife)
+}
+
+// confidenceScore returns the behavior's confidence as a score
+func (s *RelevanceScorer) confidenceScore(behavior *models.Behavior) float64 {
+	return behavior.Confidence
+}
+
+// priorityScore normalizes priority to a 0-1 score
+func (s *RelevanceScorer) priorityScore(behavior *models.Behavior) float64 {
+	// Assume priority is typically 0-10, normalize to 0-1
+	priority := behavior.Priority
+	if priority < 0 {
+		priority = 0
+	}
+	if priority > 10 {
+		priority = 10
+	}
+	return float64(priority) / 10.0
+}
+
+// kindBoost returns the score multiplier for a behavior kind
+func (s *RelevanceScorer) kindBoost(kind models.BehaviorKind) float64 {
+	if boost, ok := s.config.KindBoosts[kind]; ok {
+		return boost
+	}
+	return 1.0
+}

--- a/internal/ranking/scorer_test.go
+++ b/internal/ranking/scorer_test.go
@@ -1,0 +1,403 @@
+package ranking
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+)
+
+func TestNewRelevanceScorer(t *testing.T) {
+	config := DefaultScorerConfig()
+	scorer := NewRelevanceScorer(config)
+
+	if scorer == nil {
+		t.Fatal("expected scorer to be non-nil")
+	}
+
+	// Check weights are normalized
+	totalWeight := scorer.config.ContextWeight + scorer.config.UsageWeight +
+		scorer.config.RecencyWeight + scorer.config.ConfidenceWeight +
+		scorer.config.PriorityWeight
+
+	if math.Abs(totalWeight-1.0) > 0.001 {
+		t.Errorf("weights should sum to 1.0, got %f", totalWeight)
+	}
+}
+
+func TestRelevanceScorer_Score_NilBehavior(t *testing.T) {
+	scorer := NewRelevanceScorer(DefaultScorerConfig())
+	result := scorer.Score(nil, nil)
+
+	if result.Score != 0 {
+		t.Errorf("nil behavior should have score 0, got %f", result.Score)
+	}
+}
+
+func TestRelevanceScorer_Score_Basic(t *testing.T) {
+	scorer := NewRelevanceScorer(DefaultScorerConfig())
+	now := time.Now()
+
+	behavior := &models.Behavior{
+		ID:         "test",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		Stats: models.BehaviorStats{
+			TimesActivated: 10,
+			TimesFollowed:  8,
+			CreatedAt:      now.Add(-24 * time.Hour),
+			UpdatedAt:      now.Add(-1 * time.Hour),
+		},
+	}
+
+	result := scorer.Score(behavior, nil)
+
+	if result.Score <= 0 {
+		t.Error("expected positive score")
+	}
+	if result.Behavior != behavior {
+		t.Error("expected behavior reference to be preserved")
+	}
+}
+
+func TestRelevanceScorer_Score_ConstraintBoost(t *testing.T) {
+	scorer := NewRelevanceScorer(DefaultScorerConfig())
+	now := time.Now()
+
+	constraint := &models.Behavior{
+		ID:         "constraint",
+		Kind:       models.BehaviorKindConstraint,
+		Confidence: 0.8,
+		Priority:   5,
+		Stats: models.BehaviorStats{
+			TimesActivated: 10,
+			TimesFollowed:  8,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+
+	directive := &models.Behavior{
+		ID:         "directive",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		Stats: models.BehaviorStats{
+			TimesActivated: 10,
+			TimesFollowed:  8,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+
+	constraintScore := scorer.Score(constraint, nil)
+	directiveScore := scorer.Score(directive, nil)
+
+	// Constraints should score higher due to kind boost
+	if constraintScore.Score <= directiveScore.Score {
+		t.Errorf("constraint score (%f) should be > directive score (%f)",
+			constraintScore.Score, directiveScore.Score)
+	}
+
+	// Verify kind boosts are applied correctly
+	if constraintScore.KindBoost != 2.0 {
+		t.Errorf("constraint kind boost should be 2.0, got %f", constraintScore.KindBoost)
+	}
+	if directiveScore.KindBoost != 1.5 {
+		t.Errorf("directive kind boost should be 1.5, got %f", directiveScore.KindBoost)
+	}
+}
+
+func TestRelevanceScorer_Score_UsageSignals(t *testing.T) {
+	scorer := NewRelevanceScorer(DefaultScorerConfig())
+	now := time.Now()
+
+	wellUsed := &models.Behavior{
+		ID:         "well-used",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		Stats: models.BehaviorStats{
+			TimesActivated: 100,
+			TimesFollowed:  90,
+			TimesConfirmed: 5,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+
+	poorlyUsed := &models.Behavior{
+		ID:         "poorly-used",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		Stats: models.BehaviorStats{
+			TimesActivated:  100,
+			TimesFollowed:   10,
+			TimesOverridden: 80,
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		},
+	}
+
+	wellUsedScore := scorer.Score(wellUsed, nil)
+	poorlyUsedScore := scorer.Score(poorlyUsed, nil)
+
+	if wellUsedScore.UsageScore <= poorlyUsedScore.UsageScore {
+		t.Errorf("well-used score (%f) should be > poorly-used score (%f)",
+			wellUsedScore.UsageScore, poorlyUsedScore.UsageScore)
+	}
+}
+
+func TestRelevanceScorer_Score_Recency(t *testing.T) {
+	scorer := NewRelevanceScorer(DefaultScorerConfig())
+	now := time.Now()
+
+	recent := &models.Behavior{
+		ID:         "recent",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		Stats: models.BehaviorStats{
+			CreatedAt: now.Add(-1 * time.Hour),
+			UpdatedAt: now.Add(-1 * time.Hour),
+		},
+	}
+
+	old := &models.Behavior{
+		ID:         "old",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		Stats: models.BehaviorStats{
+			CreatedAt: now.Add(-30 * 24 * time.Hour),
+			UpdatedAt: now.Add(-30 * 24 * time.Hour),
+		},
+	}
+
+	recentScore := scorer.Score(recent, nil)
+	oldScore := scorer.Score(old, nil)
+
+	if recentScore.RecencyScore <= oldScore.RecencyScore {
+		t.Errorf("recent score (%f) should be > old score (%f)",
+			recentScore.RecencyScore, oldScore.RecencyScore)
+	}
+}
+
+func TestRelevanceScorer_Score_ContextSpecificity(t *testing.T) {
+	scorer := NewRelevanceScorer(DefaultScorerConfig())
+	now := time.Now()
+
+	ctx := &models.ContextSnapshot{
+		FilePath:     "main.go",
+		FileLanguage: "go",
+		Task:         "development",
+	}
+
+	global := &models.Behavior{
+		ID:         "global",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		When:       nil, // No predicate = global
+		Stats: models.BehaviorStats{
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+	}
+
+	specific := &models.Behavior{
+		ID:         "specific",
+		Kind:       models.BehaviorKindDirective,
+		Confidence: 0.8,
+		Priority:   5,
+		When: map[string]interface{}{
+			"language": "go",
+			"task":     "development",
+		},
+		Stats: models.BehaviorStats{
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+	}
+
+	globalScore := scorer.Score(global, ctx)
+	specificScore := scorer.Score(specific, ctx)
+
+	if specificScore.ContextScore <= globalScore.ContextScore {
+		t.Errorf("specific context score (%f) should be > global context score (%f)",
+			specificScore.ContextScore, globalScore.ContextScore)
+	}
+}
+
+func TestRelevanceScorer_ScoreBatch(t *testing.T) {
+	scorer := NewRelevanceScorer(DefaultScorerConfig())
+	now := time.Now()
+
+	behaviors := []models.Behavior{
+		{ID: "b1", Kind: models.BehaviorKindDirective, Confidence: 0.8, Stats: models.BehaviorStats{CreatedAt: now, UpdatedAt: now}},
+		{ID: "b2", Kind: models.BehaviorKindConstraint, Confidence: 0.9, Stats: models.BehaviorStats{CreatedAt: now, UpdatedAt: now}},
+		{ID: "b3", Kind: models.BehaviorKindPreference, Confidence: 0.7, Stats: models.BehaviorStats{CreatedAt: now, UpdatedAt: now}},
+	}
+
+	results := scorer.ScoreBatch(behaviors, nil)
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	for i, result := range results {
+		if result.Behavior == nil {
+			t.Errorf("result %d has nil behavior", i)
+		}
+		if result.Score <= 0 {
+			t.Errorf("result %d has non-positive score: %f", i, result.Score)
+		}
+	}
+}
+
+func TestExponentialDecay(t *testing.T) {
+	halfLife := 7 * 24 * time.Hour
+
+	tests := []struct {
+		name    string
+		time    time.Time
+		wantMin float64
+		wantMax float64
+	}{
+		{
+			name:    "zero time",
+			time:    time.Time{},
+			wantMin: 0,
+			wantMax: 0.001,
+		},
+		{
+			name:    "now",
+			time:    time.Now(),
+			wantMin: 0.99,
+			wantMax: 1.0,
+		},
+		{
+			name:    "one half-life ago",
+			time:    time.Now().Add(-halfLife),
+			wantMin: 0.45,
+			wantMax: 0.55,
+		},
+		{
+			name:    "two half-lives ago",
+			time:    time.Now().Add(-2 * halfLife),
+			wantMin: 0.20,
+			wantMax: 0.30,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := ExponentialDecay(tt.time, halfLife)
+			if score < tt.wantMin || score > tt.wantMax {
+				t.Errorf("ExponentialDecay() = %f, want in [%f, %f]", score, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestLinearDecay(t *testing.T) {
+	maxAge := 24 * time.Hour
+
+	tests := []struct {
+		name    string
+		time    time.Time
+		wantMin float64
+		wantMax float64
+	}{
+		{
+			name:    "zero time",
+			time:    time.Time{},
+			wantMin: 0,
+			wantMax: 0.001,
+		},
+		{
+			name:    "now",
+			time:    time.Now(),
+			wantMin: 0.99,
+			wantMax: 1.0,
+		},
+		{
+			name:    "half maxAge ago",
+			time:    time.Now().Add(-maxAge / 2),
+			wantMin: 0.45,
+			wantMax: 0.55,
+		},
+		{
+			name:    "past maxAge",
+			time:    time.Now().Add(-2 * maxAge),
+			wantMin: 0,
+			wantMax: 0.001,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := LinearDecay(tt.time, maxAge)
+			if score < tt.wantMin || score > tt.wantMax {
+				t.Errorf("LinearDecay() = %f, want in [%f, %f]", score, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestStepDecay(t *testing.T) {
+	recent := 1 * time.Hour
+	medium := 24 * time.Hour
+	old := 7 * 24 * time.Hour
+
+	tests := []struct {
+		name string
+		time time.Time
+		want float64
+	}{
+		{
+			name: "very recent",
+			time: time.Now().Add(-30 * time.Minute),
+			want: 1.0,
+		},
+		{
+			name: "medium recent",
+			time: time.Now().Add(-6 * time.Hour),
+			want: 0.75,
+		},
+		{
+			name: "somewhat old",
+			time: time.Now().Add(-3 * 24 * time.Hour),
+			want: 0.5,
+		},
+		{
+			name: "very old",
+			time: time.Now().Add(-30 * 24 * time.Hour),
+			want: 0.25,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := StepDecay(tt.time, recent, medium, old)
+			if score != tt.want {
+				t.Errorf("StepDecay() = %f, want %f", score, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoostedDecay(t *testing.T) {
+	halfLife := 24 * time.Hour
+	minScore := 0.1
+
+	veryOld := time.Now().Add(-365 * 24 * time.Hour)
+	score := BoostedDecay(veryOld, halfLife, minScore)
+
+	if score < minScore {
+		t.Errorf("BoostedDecay() = %f, should not be below minScore %f", score, minScore)
+	}
+}

--- a/internal/summarization/rules.go
+++ b/internal/summarization/rules.go
@@ -1,0 +1,299 @@
+package summarization
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+)
+
+// Compiled regex patterns (compiled once at package init for performance)
+var (
+	preferOverRe = regexp.MustCompile(`(?i)prefer\s+(\S+(?:\s+\S+)?)\s+(?:over|instead of|rather than)\s+(\S+(?:\s+\S+)?)`)
+	useInsteadRe = regexp.MustCompile(`(?i)use\s+(\S+(?:\s+\S+)?)\s+(?:instead of|rather than)\s+(\S+(?:\s+\S+)?)`)
+	whitespaceRe = regexp.MustCompile(`\s+`)
+)
+
+// RuleSummarizer implements Summarizer using rule-based compression
+type RuleSummarizer struct {
+	config SummarizerConfig
+}
+
+// Summarize generates a short summary for a behavior using rules
+func (s *RuleSummarizer) Summarize(behavior *models.Behavior) (string, error) {
+	if behavior == nil {
+		return "", nil
+	}
+
+	// If summary already exists and is within length, use it
+	if behavior.Content.Summary != "" && len(behavior.Content.Summary) <= s.config.MaxLength {
+		return behavior.Content.Summary, nil
+	}
+
+	// Start with canonical content
+	text := behavior.Content.Canonical
+	if text == "" {
+		text = behavior.Name
+	}
+	if text == "" {
+		return "", nil
+	}
+
+	// Apply compression rules
+	summary := s.compress(text, behavior.Kind)
+
+	// Truncate if still too long
+	summary = s.truncate(summary)
+
+	return summary, nil
+}
+
+// SummarizeBatch generates summaries for multiple behaviors
+func (s *RuleSummarizer) SummarizeBatch(behaviors []*models.Behavior) (map[string]string, error) {
+	results := make(map[string]string, len(behaviors))
+	for _, b := range behaviors {
+		if b == nil {
+			continue
+		}
+		summary, err := s.Summarize(b)
+		if err != nil {
+			return nil, err
+		}
+		results[b.ID] = summary
+	}
+	return results, nil
+}
+
+// compress applies rule-based compression to text
+func (s *RuleSummarizer) compress(text string, kind models.BehaviorKind) string {
+	result := text
+
+	// Step 1: Remove common filler phrases
+	result = s.removeFiller(result)
+
+	// Step 2: Extract key pattern based on kind
+	result = s.extractKeyPattern(result, kind)
+
+	// Step 3: Compress common phrases
+	result = s.compressCommonPhrases(result)
+
+	// Step 4: Clean up whitespace
+	result = s.cleanWhitespace(result)
+
+	return result
+}
+
+// removeFiller removes common filler words and phrases
+func (s *RuleSummarizer) removeFiller(text string) string {
+	fillers := []string{
+		"please ",
+		"always ",
+		"make sure to ",
+		"be sure to ",
+		"remember to ",
+		"don't forget to ",
+		"it is important to ",
+		"you should ",
+		"you must ",
+		"we should ",
+		"when possible, ",
+		"whenever possible, ",
+		"if possible, ",
+		"in general, ",
+		"generally, ",
+		"typically, ",
+		"usually, ",
+		"basically, ",
+		"essentially, ",
+		"the following ",
+		"as follows: ",
+	}
+
+	result := text
+	lowerResult := strings.ToLower(result)
+
+	for _, filler := range fillers {
+		idx := strings.Index(lowerResult, filler)
+		if idx != -1 {
+			result = result[:idx] + result[idx+len(filler):]
+			lowerResult = strings.ToLower(result)
+		}
+	}
+
+	return result
+}
+
+// extractKeyPattern extracts the key action/constraint based on behavior kind
+func (s *RuleSummarizer) extractKeyPattern(text string, kind models.BehaviorKind) string {
+	switch kind {
+	case models.BehaviorKindConstraint:
+		return s.extractConstraintPattern(text)
+	case models.BehaviorKindPreference:
+		return s.extractPreferencePattern(text)
+	case models.BehaviorKindDirective:
+		return s.extractDirectivePattern(text)
+	default:
+		return text
+	}
+}
+
+// extractConstraintPattern extracts "Never X" or "Don't X" patterns
+func (s *RuleSummarizer) extractConstraintPattern(text string) string {
+	lower := strings.ToLower(text)
+
+	// If it already starts with a constraint word, keep the structure
+	constraintPrefixes := []string{"never ", "don't ", "do not ", "avoid ", "no "}
+	for _, prefix := range constraintPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			// Extract just the action part
+			rest := text[len(prefix):]
+			// Take first clause (up to comma, semicolon, or period)
+			rest = s.firstClause(rest)
+			if s.config.PreservePrefixes {
+				return "Never " + strings.ToLower(rest)
+			}
+			return rest
+		}
+	}
+
+	// Convert to constraint form
+	if s.config.PreservePrefixes {
+		return "Never " + strings.ToLower(s.firstClause(text))
+	}
+	return s.firstClause(text)
+}
+
+// extractPreferencePattern extracts "Prefer X over Y" patterns
+func (s *RuleSummarizer) extractPreferencePattern(text string) string {
+	lower := strings.ToLower(text)
+
+	// Look for "prefer X over Y" pattern (using pre-compiled regex)
+	if matches := preferOverRe.FindStringSubmatch(text); len(matches) >= 3 {
+		return matches[1] + " > " + matches[2]
+	}
+
+	// Look for "use X instead of Y" pattern (using pre-compiled regex)
+	if matches := useInsteadRe.FindStringSubmatch(text); len(matches) >= 3 {
+		return matches[1] + " > " + matches[2]
+	}
+
+	// If starts with "prefer", extract the preference
+	if strings.HasPrefix(lower, "prefer ") {
+		rest := text[7:]
+		return "Prefer " + s.firstClause(rest)
+	}
+
+	return s.firstClause(text)
+}
+
+// extractDirectivePattern extracts directive patterns
+func (s *RuleSummarizer) extractDirectivePattern(text string) string {
+	// Directives are usually action-oriented, extract first clause
+	return s.firstClause(text)
+}
+
+// compressCommonPhrases replaces common phrases with shorter versions
+func (s *RuleSummarizer) compressCommonPhrases(text string) string {
+	replacements := map[string]string{
+		"instead of":            ">",
+		"rather than":           ">",
+		"as opposed to":         ">",
+		"for example":           "e.g.",
+		"such as":               "e.g.",
+		"in order to":           "to",
+		"due to the fact":       "because",
+		"at this point":         "now",
+		"at this time":          "now",
+		"in the event of":       "if",
+		"in the case of":        "for",
+		"with respect to":       "for",
+		"with regard to":        "for",
+		"on a regular basis":    "regularly",
+		"environment variables": "env vars",
+		"configuration":         "config",
+		"documentation":         "docs",
+		"implementation":        "impl",
+		"functionality":         "feature",
+		"application":           "app",
+		"directory":             "dir",
+		"repository":            "repo",
+	}
+
+	result := text
+	for phrase, replacement := range replacements {
+		result = strings.ReplaceAll(result, phrase, replacement)
+		// Also replace title case version (e.g., "Instead of" -> ">")
+		result = strings.ReplaceAll(result, titleCase(phrase), replacement)
+	}
+
+	return result
+}
+
+// titleCase returns a string with the first letter of each word capitalized
+func titleCase(s string) string {
+	if s == "" {
+		return s
+	}
+	words := strings.Fields(s)
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(string(w[0])) + strings.ToLower(w[1:])
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+// firstClause extracts the first clause of a sentence
+func (s *RuleSummarizer) firstClause(text string) string {
+	// Find first delimiter
+	delimiters := []string{". ", ", ", "; ", " - ", " — ", " because ", " since ", " when ", " if "}
+	minIdx := len(text)
+
+	for _, d := range delimiters {
+		idx := strings.Index(strings.ToLower(text), d)
+		if idx > 0 && idx < minIdx {
+			minIdx = idx
+		}
+	}
+
+	if minIdx < len(text) {
+		return strings.TrimSpace(text[:minIdx])
+	}
+
+	return strings.TrimSpace(text)
+}
+
+// cleanWhitespace normalizes whitespace in text
+func (s *RuleSummarizer) cleanWhitespace(text string) string {
+	// Replace multiple spaces with single space (using pre-compiled regex)
+	result := whitespaceRe.ReplaceAllString(text, " ")
+
+	// Trim leading/trailing whitespace
+	result = strings.TrimSpace(result)
+
+	// Capitalize first letter
+	if len(result) > 0 {
+		runes := []rune(result)
+		runes[0] = unicode.ToUpper(runes[0])
+		result = string(runes)
+	}
+
+	return result
+}
+
+// truncate shortens text to max length with ellipsis
+func (s *RuleSummarizer) truncate(text string) string {
+	if len(text) <= s.config.MaxLength {
+		return text
+	}
+
+	// Try to truncate at word boundary
+	truncated := text[:s.config.MaxLength-3]
+	lastSpace := strings.LastIndex(truncated, " ")
+	if lastSpace > s.config.MaxLength/2 {
+		truncated = truncated[:lastSpace]
+	}
+
+	return truncated + "..."
+}

--- a/internal/summarization/rules_test.go
+++ b/internal/summarization/rules_test.go
@@ -1,0 +1,313 @@
+package summarization
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+)
+
+func TestRuleSummarizer_Summarize_Basic(t *testing.T) {
+	s := NewRuleSummarizer(DefaultConfig())
+
+	tests := []struct {
+		name     string
+		behavior *models.Behavior
+		wantLen  int
+		contains string
+	}{
+		{
+			name:     "nil behavior",
+			behavior: nil,
+			wantLen:  0,
+		},
+		{
+			name: "empty content",
+			behavior: &models.Behavior{
+				ID:      "b1",
+				Content: models.BehaviorContent{},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "short canonical already fits",
+			behavior: &models.Behavior{
+				ID:      "b2",
+				Content: models.BehaviorContent{Canonical: "Use Go modules"},
+			},
+			contains: "Use Go modules",
+		},
+		{
+			name: "existing summary used",
+			behavior: &models.Behavior{
+				ID: "b3",
+				Content: models.BehaviorContent{
+					Canonical: "This is a very long canonical content that exceeds the limit",
+					Summary:   "Short summary",
+				},
+			},
+			contains: "Short summary",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.Summarize(tt.behavior)
+			if err != nil {
+				t.Errorf("Summarize() error = %v", err)
+				return
+			}
+			if tt.wantLen > 0 && len(got) != tt.wantLen {
+				t.Errorf("Summarize() len = %d, want %d", len(got), tt.wantLen)
+			}
+			if tt.contains != "" && !strings.Contains(got, tt.contains) {
+				t.Errorf("Summarize() = %q, want to contain %q", got, tt.contains)
+			}
+		})
+	}
+}
+
+func TestRuleSummarizer_Summarize_Constraint(t *testing.T) {
+	s := NewRuleSummarizer(DefaultConfig())
+
+	tests := []struct {
+		name       string
+		canonical  string
+		wantPrefix string
+	}{
+		{
+			name:       "never prefix preserved",
+			canonical:  "Never commit .env files to the repository",
+			wantPrefix: "Never",
+		},
+		{
+			name:       "don't converted to never",
+			canonical:  "Don't use global variables",
+			wantPrefix: "Never",
+		},
+		{
+			name:       "avoid converted to never",
+			canonical:  "Avoid hardcoding credentials in source code",
+			wantPrefix: "Never",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &models.Behavior{
+				ID:   "test",
+				Kind: models.BehaviorKindConstraint,
+				Content: models.BehaviorContent{
+					Canonical: tt.canonical,
+				},
+			}
+			got, err := s.Summarize(b)
+			if err != nil {
+				t.Errorf("Summarize() error = %v", err)
+				return
+			}
+			if !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("Summarize() = %q, want prefix %q", got, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+func TestRuleSummarizer_Summarize_Preference(t *testing.T) {
+	s := NewRuleSummarizer(DefaultConfig())
+
+	tests := []struct {
+		name      string
+		canonical string
+		contains  string
+	}{
+		{
+			name:      "prefer over pattern extracts comparison",
+			canonical: "Prefer pathlib over os.path for file operations",
+			contains:  " > ",
+		},
+		{
+			name:      "use instead of pattern extracts comparison",
+			canonical: "Use context.Context instead of timeouts",
+			contains:  " > ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &models.Behavior{
+				ID:   "test",
+				Kind: models.BehaviorKindPreference,
+				Content: models.BehaviorContent{
+					Canonical: tt.canonical,
+				},
+			}
+			got, err := s.Summarize(b)
+			if err != nil {
+				t.Errorf("Summarize() error = %v", err)
+				return
+			}
+			if !strings.Contains(got, tt.contains) {
+				t.Errorf("Summarize() = %q, want to contain %q", got, tt.contains)
+			}
+		})
+	}
+}
+
+func TestRuleSummarizer_Summarize_Truncation(t *testing.T) {
+	config := SummarizerConfig{MaxLength: 30}
+	s := NewRuleSummarizer(config)
+
+	b := &models.Behavior{
+		ID:   "test",
+		Kind: models.BehaviorKindDirective,
+		Content: models.BehaviorContent{
+			Canonical: "This is a very long directive that should be truncated to fit within the maximum length",
+		},
+	}
+
+	got, err := s.Summarize(b)
+	if err != nil {
+		t.Errorf("Summarize() error = %v", err)
+		return
+	}
+
+	if len(got) > 30 {
+		t.Errorf("Summarize() len = %d, want <= 30", len(got))
+	}
+
+	if !strings.HasSuffix(got, "...") {
+		t.Errorf("Summarize() = %q, want to end with '...'", got)
+	}
+}
+
+func TestRuleSummarizer_Summarize_RemovesFiller(t *testing.T) {
+	s := NewRuleSummarizer(DefaultConfig())
+
+	tests := []struct {
+		name       string
+		canonical  string
+		notContain string
+	}{
+		{
+			name:       "removes please",
+			canonical:  "Please use consistent naming",
+			notContain: "please",
+		},
+		{
+			name:       "removes make sure to",
+			canonical:  "Make sure to run tests before committing",
+			notContain: "make sure to",
+		},
+		{
+			name:       "removes remember to",
+			canonical:  "Remember to update documentation",
+			notContain: "remember to",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &models.Behavior{
+				ID:   "test",
+				Kind: models.BehaviorKindDirective,
+				Content: models.BehaviorContent{
+					Canonical: tt.canonical,
+				},
+			}
+			got, err := s.Summarize(b)
+			if err != nil {
+				t.Errorf("Summarize() error = %v", err)
+				return
+			}
+			if strings.Contains(strings.ToLower(got), tt.notContain) {
+				t.Errorf("Summarize() = %q, should not contain %q", got, tt.notContain)
+			}
+		})
+	}
+}
+
+func TestRuleSummarizer_SummarizeBatch(t *testing.T) {
+	s := NewRuleSummarizer(DefaultConfig())
+
+	behaviors := []*models.Behavior{
+		{ID: "b1", Content: models.BehaviorContent{Canonical: "First behavior"}},
+		{ID: "b2", Content: models.BehaviorContent{Canonical: "Second behavior"}},
+		nil,
+		{ID: "b3", Content: models.BehaviorContent{Canonical: "Third behavior"}},
+	}
+
+	results, err := s.SummarizeBatch(behaviors)
+	if err != nil {
+		t.Errorf("SummarizeBatch() error = %v", err)
+		return
+	}
+
+	if len(results) != 3 {
+		t.Errorf("SummarizeBatch() returned %d results, want 3", len(results))
+	}
+
+	for _, id := range []string{"b1", "b2", "b3"} {
+		if _, ok := results[id]; !ok {
+			t.Errorf("SummarizeBatch() missing result for %s", id)
+		}
+	}
+}
+
+func TestRuleSummarizer_CompressCommonPhrases(t *testing.T) {
+	s := &RuleSummarizer{config: DefaultConfig()}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Use pathlib instead of os.path", "Use pathlib > os.path"},
+		{"Check for example the docs", "Check e.g. the docs"},
+		{"in order to build", "to build"},
+		{"environment variables", "env vars"},
+		{"Update the documentation", "Update the docs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := s.compressCommonPhrases(tt.input)
+			if got != tt.want {
+				t.Errorf("compressCommonPhrases(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRuleSummarizer_FirstClause(t *testing.T) {
+	s := &RuleSummarizer{config: DefaultConfig()}
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Use Go modules. They are better.", "Use Go modules"},
+		{"Run tests, then commit", "Run tests"},
+		{"Format code; check lint", "Format code"},
+		{"Check docs because they matter", "Check docs"},
+		{"Single clause only", "Single clause only"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := s.firstClause(tt.input)
+			if got != tt.want {
+				t.Errorf("firstClause(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewRuleSummarizer_DefaultMaxLength(t *testing.T) {
+	// Test that zero MaxLength gets default
+	s := NewRuleSummarizer(SummarizerConfig{MaxLength: 0})
+	rs := s.(*RuleSummarizer)
+
+	if rs.config.MaxLength != 60 {
+		t.Errorf("expected default MaxLength 60, got %d", rs.config.MaxLength)
+	}
+}

--- a/internal/summarization/summarizer.go
+++ b/internal/summarization/summarizer.go
@@ -1,0 +1,40 @@
+package summarization
+
+import (
+	"github.com/nvandessel/feedback-loop/internal/models"
+)
+
+// Summarizer generates compressed summaries of behaviors
+type Summarizer interface {
+	// Summarize generates a short summary for a behavior
+	// The summary should be ~60 characters, suitable for quick reference
+	Summarize(behavior *models.Behavior) (string, error)
+
+	// SummarizeBatch generates summaries for multiple behaviors
+	SummarizeBatch(behaviors []*models.Behavior) (map[string]string, error)
+}
+
+// SummarizerConfig holds configuration for summarizers
+type SummarizerConfig struct {
+	// MaxLength is the maximum length for summaries (default: 60)
+	MaxLength int
+
+	// PreservePrefixes keeps kind-specific prefixes like "Never" for constraints
+	PreservePrefixes bool
+}
+
+// DefaultConfig returns the default summarizer configuration
+func DefaultConfig() SummarizerConfig {
+	return SummarizerConfig{
+		MaxLength:        60,
+		PreservePrefixes: true,
+	}
+}
+
+// NewRuleSummarizer creates a new rule-based summarizer
+func NewRuleSummarizer(config SummarizerConfig) Summarizer {
+	if config.MaxLength <= 0 {
+		config.MaxLength = 60
+	}
+	return &RuleSummarizer{config: config}
+}

--- a/internal/tiering/assigner.go
+++ b/internal/tiering/assigner.go
@@ -1,0 +1,208 @@
+package tiering
+
+import (
+	"sort"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+	"github.com/nvandessel/feedback-loop/internal/ranking"
+	"github.com/nvandessel/feedback-loop/internal/summarization"
+)
+
+// TierAssignerConfig configures the tier assigner
+type TierAssignerConfig struct {
+	// FullTierPercent is the percentage of budget for full-tier behaviors (default: 0.6)
+	FullTierPercent float64
+
+	// SummaryTierPercent is the percentage of budget for summary-tier behaviors (default: 0.3)
+	SummaryTierPercent float64
+
+	// OverheadPercent is reserved for formatting overhead (default: 0.1)
+	OverheadPercent float64
+
+	// MinFullBehaviors is the minimum number of behaviors at full tier
+	MinFullBehaviors int
+
+	// ConstraintsAlwaysFull ensures constraints always get full tier
+	ConstraintsAlwaysFull bool
+}
+
+// DefaultTierAssignerConfig returns the default tier assigner configuration
+func DefaultTierAssignerConfig() TierAssignerConfig {
+	return TierAssignerConfig{
+		FullTierPercent:       0.60,
+		SummaryTierPercent:    0.30,
+		OverheadPercent:       0.10,
+		MinFullBehaviors:      3,
+		ConstraintsAlwaysFull: true,
+	}
+}
+
+// TierAssigner assigns injection tiers to behaviors based on budget
+type TierAssigner struct {
+	config     TierAssignerConfig
+	scorer     *ranking.RelevanceScorer
+	summarizer summarization.Summarizer
+}
+
+// NewTierAssigner creates a new tier assigner
+func NewTierAssigner(config TierAssignerConfig, scorer *ranking.RelevanceScorer, summarizer summarization.Summarizer) *TierAssigner {
+	// Validate and normalize percentages
+	total := config.FullTierPercent + config.SummaryTierPercent + config.OverheadPercent
+	if total > 0 && total != 1.0 {
+		config.FullTierPercent /= total
+		config.SummaryTierPercent /= total
+		config.OverheadPercent /= total
+	}
+
+	if config.MinFullBehaviors < 0 {
+		config.MinFullBehaviors = 0
+	}
+
+	return &TierAssigner{
+		config:     config,
+		scorer:     scorer,
+		summarizer: summarizer,
+	}
+}
+
+// AssignTiers creates an injection plan for the given behaviors within the token budget
+func (a *TierAssigner) AssignTiers(behaviors []models.Behavior, ctx *models.ContextSnapshot, tokenBudget int) *models.InjectionPlan {
+	if len(behaviors) == 0 {
+		return &models.InjectionPlan{
+			TokenBudget: tokenBudget,
+		}
+	}
+
+	// Score all behaviors
+	scored := a.scorer.ScoreBatch(behaviors, ctx)
+
+	// Sort by score descending
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].Score > scored[j].Score
+	})
+
+	// Calculate budget tiers
+	fullBudget := int(float64(tokenBudget) * a.config.FullTierPercent)
+	summaryBudget := int(float64(tokenBudget) * a.config.SummaryTierPercent)
+
+	plan := &models.InjectionPlan{
+		TokenBudget:         tokenBudget,
+		FullBehaviors:       make([]models.InjectedBehavior, 0),
+		SummarizedBehaviors: make([]models.InjectedBehavior, 0),
+		OmittedBehaviors:    make([]models.InjectedBehavior, 0),
+	}
+
+	fullTokensUsed := 0
+	summaryTokensUsed := 0
+
+	// First pass: assign constraints to full tier (if configured)
+	if a.config.ConstraintsAlwaysFull {
+		for i, s := range scored {
+			if s.Behavior.Kind != models.BehaviorKindConstraint {
+				continue
+			}
+			tokenCost := a.estimateTokens(s.Behavior.Content.Canonical)
+			injected := models.InjectedBehavior{
+				Behavior:  s.Behavior,
+				Tier:      models.TierFull,
+				Content:   s.Behavior.Content.Canonical,
+				TokenCost: tokenCost,
+				Score:     s.Score,
+			}
+			plan.FullBehaviors = append(plan.FullBehaviors, injected)
+			fullTokensUsed += tokenCost
+			// Mark as processed
+			scored[i].Score = -1
+		}
+	}
+
+	// Second pass: fill remaining full budget
+	for _, s := range scored {
+		if s.Score < 0 {
+			continue // Already processed
+		}
+
+		tokenCost := a.estimateTokens(s.Behavior.Content.Canonical)
+		if fullTokensUsed+tokenCost <= fullBudget || len(plan.FullBehaviors) < a.config.MinFullBehaviors {
+			injected := models.InjectedBehavior{
+				Behavior:  s.Behavior,
+				Tier:      models.TierFull,
+				Content:   s.Behavior.Content.Canonical,
+				TokenCost: tokenCost,
+				Score:     s.Score,
+			}
+			plan.FullBehaviors = append(plan.FullBehaviors, injected)
+			fullTokensUsed += tokenCost
+		} else {
+			// Try to fit as summary
+			summary := a.getSummary(s.Behavior)
+			summaryTokenCost := a.estimateTokens(summary)
+
+			if summaryTokensUsed+summaryTokenCost <= summaryBudget {
+				injected := models.InjectedBehavior{
+					Behavior:  s.Behavior,
+					Tier:      models.TierSummary,
+					Content:   summary,
+					TokenCost: summaryTokenCost,
+					Score:     s.Score,
+				}
+				plan.SummarizedBehaviors = append(plan.SummarizedBehaviors, injected)
+				summaryTokensUsed += summaryTokenCost
+			} else {
+				// Omit entirely
+				injected := models.InjectedBehavior{
+					Behavior:  s.Behavior,
+					Tier:      models.TierOmitted,
+					Content:   "",
+					TokenCost: 0,
+					Score:     s.Score,
+				}
+				plan.OmittedBehaviors = append(plan.OmittedBehaviors, injected)
+			}
+		}
+	}
+
+	plan.TotalTokens = fullTokensUsed + summaryTokensUsed
+
+	return plan
+}
+
+// getSummary retrieves or generates a summary for a behavior
+func (a *TierAssigner) getSummary(behavior *models.Behavior) string {
+	// Use existing summary if available
+	if behavior.Content.Summary != "" {
+		return behavior.Content.Summary
+	}
+
+	// Generate summary using summarizer
+	if a.summarizer != nil {
+		summary, err := a.summarizer.Summarize(behavior)
+		if err == nil && summary != "" {
+			return summary
+		}
+	}
+
+	// Fallback: truncate canonical content
+	canonical := behavior.Content.Canonical
+	if len(canonical) > 60 {
+		return canonical[:57] + "..."
+	}
+	return canonical
+}
+
+// estimateTokens estimates token count for text
+func (a *TierAssigner) estimateTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+	// Rough estimate: 1 token ≈ 4 characters
+	return (len(text) + 3) / 4
+}
+
+// QuickAssign is a convenience method that creates a scorer and summarizer internally
+func QuickAssign(behaviors []models.Behavior, tokenBudget int) *models.InjectionPlan {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, summarizer)
+	return assigner.AssignTiers(behaviors, nil, tokenBudget)
+}

--- a/internal/tiering/assigner_test.go
+++ b/internal/tiering/assigner_test.go
@@ -1,0 +1,323 @@
+package tiering
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+	"github.com/nvandessel/feedback-loop/internal/ranking"
+	"github.com/nvandessel/feedback-loop/internal/summarization"
+)
+
+func TestDefaultTierAssignerConfig(t *testing.T) {
+	config := DefaultTierAssignerConfig()
+
+	// Check percentages sum to ~1.0 (allow for floating point)
+	total := config.FullTierPercent + config.SummaryTierPercent + config.OverheadPercent
+	if total < 0.99 || total > 1.01 {
+		t.Errorf("percentages should sum to ~1.0, got %f", total)
+	}
+
+	if !config.ConstraintsAlwaysFull {
+		t.Error("ConstraintsAlwaysFull should default to true")
+	}
+}
+
+func TestTierAssigner_AssignTiers_Empty(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, summarizer)
+
+	plan := assigner.AssignTiers(nil, nil, 1000)
+
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+	if plan.TokenBudget != 1000 {
+		t.Errorf("expected TokenBudget 1000, got %d", plan.TokenBudget)
+	}
+	if len(plan.FullBehaviors) != 0 {
+		t.Errorf("expected empty FullBehaviors, got %d", len(plan.FullBehaviors))
+	}
+}
+
+func TestTierAssigner_AssignTiers_ConstraintsPrioritized(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, summarizer)
+
+	now := time.Now()
+	behaviors := []models.Behavior{
+		{
+			ID:         "directive",
+			Kind:       models.BehaviorKindDirective,
+			Confidence: 0.9,
+			Priority:   10,
+			Content:    models.BehaviorContent{Canonical: "This is a directive"},
+			Stats:      models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		},
+		{
+			ID:         "constraint",
+			Kind:       models.BehaviorKindConstraint,
+			Confidence: 0.5,
+			Priority:   1,
+			Content:    models.BehaviorContent{Canonical: "Never do this"},
+			Stats:      models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		},
+	}
+
+	plan := assigner.AssignTiers(behaviors, nil, 1000)
+
+	// Both should be full tier with adequate budget
+	if len(plan.FullBehaviors) != 2 {
+		t.Fatalf("expected 2 full behaviors, got %d", len(plan.FullBehaviors))
+	}
+
+	// Constraint should be in full tier even with lower priority/confidence
+	hasConstraint := false
+	for _, b := range plan.FullBehaviors {
+		if b.Behavior.Kind == models.BehaviorKindConstraint {
+			hasConstraint = true
+			break
+		}
+	}
+	if !hasConstraint {
+		t.Error("constraint should be in full tier")
+	}
+}
+
+func TestTierAssigner_AssignTiers_LimitedBudget(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, summarizer)
+
+	now := time.Now()
+	behaviors := make([]models.Behavior, 20)
+	for i := 0; i < 20; i++ {
+		behaviors[i] = models.Behavior{
+			ID:         "b" + string(rune('0'+i)),
+			Kind:       models.BehaviorKindDirective,
+			Confidence: 0.8,
+			Priority:   5,
+			Content:    models.BehaviorContent{Canonical: "This is a somewhat long behavior content for testing token budget limits"},
+			Stats:      models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		}
+	}
+
+	// Very small budget should cause tiering
+	plan := assigner.AssignTiers(behaviors, nil, 500)
+
+	if plan.BehaviorCount() != 20 {
+		t.Errorf("expected 20 total behaviors, got %d", plan.BehaviorCount())
+	}
+
+	// Should have some at each tier (or omitted)
+	if len(plan.FullBehaviors) == 0 {
+		t.Error("expected at least some full behaviors")
+	}
+
+	// Total tokens should be within budget
+	if plan.TotalTokens > 500 {
+		t.Errorf("total tokens %d exceeds budget 500", plan.TotalTokens)
+	}
+}
+
+func TestTierAssigner_AssignTiers_TierContent(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, summarizer)
+
+	now := time.Now()
+	behaviors := []models.Behavior{
+		{
+			ID:         "b1",
+			Kind:       models.BehaviorKindDirective,
+			Confidence: 0.9,
+			Priority:   10,
+			Content: models.BehaviorContent{
+				Canonical: "Use Go modules for dependency management",
+				Summary:   "Use Go modules",
+			},
+			Stats: models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		},
+	}
+
+	plan := assigner.AssignTiers(behaviors, nil, 1000)
+
+	if len(plan.FullBehaviors) != 1 {
+		t.Fatalf("expected 1 full behavior, got %d", len(plan.FullBehaviors))
+	}
+
+	// Full tier should have canonical content
+	full := plan.FullBehaviors[0]
+	if full.Content != "Use Go modules for dependency management" {
+		t.Errorf("full tier should have canonical content, got %s", full.Content)
+	}
+	if full.Tier != models.TierFull {
+		t.Errorf("expected TierFull, got %d", full.Tier)
+	}
+}
+
+func TestTierAssigner_AssignTiers_SummaryTier(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+
+	// Config that forces early summarization
+	config := TierAssignerConfig{
+		FullTierPercent:       0.20, // Very small full tier
+		SummaryTierPercent:    0.70,
+		OverheadPercent:       0.10,
+		MinFullBehaviors:      1,
+		ConstraintsAlwaysFull: true,
+	}
+	assigner := NewTierAssigner(config, scorer, summarizer)
+
+	now := time.Now()
+	behaviors := []models.Behavior{
+		{
+			ID:         "b1",
+			Kind:       models.BehaviorKindDirective,
+			Confidence: 1.0,
+			Priority:   10,
+			Content:    models.BehaviorContent{Canonical: "First behavior with highest priority"},
+			Stats:      models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		},
+		{
+			ID:         "b2",
+			Kind:       models.BehaviorKindDirective,
+			Confidence: 0.9,
+			Priority:   9,
+			Content: models.BehaviorContent{
+				Canonical: "Second behavior with lower priority but still important",
+				Summary:   "Second lower priority",
+			},
+			Stats: models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		},
+		{
+			ID:         "b3",
+			Kind:       models.BehaviorKindDirective,
+			Confidence: 0.8,
+			Priority:   8,
+			Content:    models.BehaviorContent{Canonical: "Third behavior"},
+			Stats:      models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		},
+	}
+
+	// Budget forces summarization
+	plan := assigner.AssignTiers(behaviors, nil, 100)
+
+	// Should have some summarized or omitted behaviors
+	if len(plan.SummarizedBehaviors)+len(plan.OmittedBehaviors) == 0 {
+		t.Log("Full:", len(plan.FullBehaviors), "Summary:", len(plan.SummarizedBehaviors), "Omitted:", len(plan.OmittedBehaviors))
+		t.Log("TotalTokens:", plan.TotalTokens, "Budget:", plan.TokenBudget)
+	}
+}
+
+func TestTierAssigner_GetSummary_Existing(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, summarizer)
+
+	behavior := &models.Behavior{
+		ID:   "test",
+		Kind: models.BehaviorKindDirective,
+		Content: models.BehaviorContent{
+			Canonical: "This is a very long canonical content that should not be used",
+			Summary:   "Short summary",
+		},
+	}
+
+	summary := assigner.getSummary(behavior)
+	if summary != "Short summary" {
+		t.Errorf("expected existing summary, got %s", summary)
+	}
+}
+
+func TestTierAssigner_GetSummary_Generated(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	summarizer := summarization.NewRuleSummarizer(summarization.DefaultConfig())
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, summarizer)
+
+	behavior := &models.Behavior{
+		ID:   "test",
+		Kind: models.BehaviorKindDirective,
+		Content: models.BehaviorContent{
+			Canonical: "Always use descriptive variable names",
+		},
+	}
+
+	summary := assigner.getSummary(behavior)
+	if summary == "" {
+		t.Error("expected generated summary")
+	}
+}
+
+func TestTierAssigner_GetSummary_Truncated(t *testing.T) {
+	scorer := ranking.NewRelevanceScorer(ranking.DefaultScorerConfig())
+	// nil summarizer to test truncation fallback
+	assigner := NewTierAssigner(DefaultTierAssignerConfig(), scorer, nil)
+
+	behavior := &models.Behavior{
+		ID:   "test",
+		Kind: models.BehaviorKindDirective,
+		Content: models.BehaviorContent{
+			Canonical: "This is a very long canonical content that exceeds sixty characters and should be truncated",
+		},
+	}
+
+	summary := assigner.getSummary(behavior)
+	if len(summary) > 60 {
+		t.Errorf("summary should be <= 60 chars, got %d", len(summary))
+	}
+	if len(summary) < 60 {
+		t.Error("expected truncated summary ending in ...")
+	}
+}
+
+func TestQuickAssign(t *testing.T) {
+	now := time.Now()
+	behaviors := []models.Behavior{
+		{
+			ID:         "b1",
+			Kind:       models.BehaviorKindDirective,
+			Confidence: 0.8,
+			Content:    models.BehaviorContent{Canonical: "Test behavior"},
+			Stats:      models.BehaviorStats{CreatedAt: now, UpdatedAt: now},
+		},
+	}
+
+	plan := QuickAssign(behaviors, 1000)
+
+	if plan == nil {
+		t.Fatal("expected non-nil plan")
+	}
+	if plan.TokenBudget != 1000 {
+		t.Errorf("expected budget 1000, got %d", plan.TokenBudget)
+	}
+}
+
+func TestInjectionPlan_Methods(t *testing.T) {
+	plan := &models.InjectionPlan{
+		FullBehaviors:       make([]models.InjectedBehavior, 5),
+		SummarizedBehaviors: make([]models.InjectedBehavior, 3),
+		OmittedBehaviors:    make([]models.InjectedBehavior, 2),
+	}
+
+	if plan.BehaviorCount() != 10 {
+		t.Errorf("BehaviorCount() = %d, want 10", plan.BehaviorCount())
+	}
+
+	if plan.IncludedCount() != 8 {
+		t.Errorf("IncludedCount() = %d, want 8", plan.IncludedCount())
+	}
+
+	included := plan.IncludedBehaviors()
+	if len(included) != 8 {
+		t.Errorf("IncludedBehaviors() len = %d, want 8", len(included))
+	}
+
+	all := plan.AllBehaviors()
+	if len(all) != 10 {
+		t.Errorf("AllBehaviors() len = %d, want 10", len(all))
+	}
+}


### PR DESCRIPTION
Enable agents to utilize learned behaviors without bloating the context window through intelligent tiered injection, summarization, and usage-based ranking.

Architecture:
  behaviors → evaluate → resolve → RANK → TIER → SUMMARIZE → compile → inject

New packages:
- internal/summarization: Rule-based behavior compression (~60 char summaries)
- internal/ranking: Multi-factor relevance scoring (context, usage, recency, confidence, priority)
- internal/tiering: Budget allocation (60% full, 30% summary, 10% overhead)

Key features:
- Constraints always get full tier (safety critical)
- Tiered injection: full content, summaries, or omitted with reference
- MCP expansion resource: floop://behaviors/expand/{id} for on-demand details
- CLI commands: floop summarize, floop stats
- Updated prompt command with --tiered and --token-budget flags

Model changes:
- BehaviorContent: Added Summary and Tags fields
- BehaviorStats: Added TimesConfirmed and LastConfirmed for positive signals
- New InjectionTier, InjectedBehavior, InjectionPlan types