### PR TITLE
fix(security): path validation for backup/restore operations [w03.3]

### DIFF
--- a/cmd/floop/cmd_backup.go
+++ b/cmd/floop/cmd_backup.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/nvandessel/feedback-loop/internal/backup"
+	"github.com/nvandessel/feedback-loop/internal/pathutil"
 	"github.com/nvandessel/feedback-loop/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,15 @@ Examples:
 					return fmt.Errorf("failed to get backup directory: %w", err)
 				}
 				outputPath = backup.GenerateBackupPath(dir)
+			} else {
+				// Validate user-specified path
+				allowedDirs, err := pathutil.DefaultAllowedBackupDirsWithProjectRoot(root)
+				if err != nil {
+					return fmt.Errorf("failed to determine allowed backup dirs: %w", err)
+				}
+				if err := pathutil.ValidatePath(outputPath, allowedDirs); err != nil {
+					return fmt.Errorf("backup path rejected: %w", err)
+				}
 			}
 
 			ctx := context.Background()
@@ -93,6 +103,15 @@ Examples:
 			root, _ := cmd.Flags().GetString("root")
 			jsonOut, _ := cmd.Flags().GetBool("json")
 			mode, _ := cmd.Flags().GetString("mode")
+
+			// Validate input path
+			allowedDirs, err := pathutil.DefaultAllowedBackupDirsWithProjectRoot(root)
+			if err != nil {
+				return fmt.Errorf("failed to determine allowed backup dirs: %w", err)
+			}
+			if err := pathutil.ValidatePath(inputPath, allowedDirs); err != nil {
+				return fmt.Errorf("restore path rejected: %w", err)
+			}
 
 			restoreMode := backup.RestoreMerge
 			if mode == "replace" {

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -12,12 +12,13 @@ import (
 
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/nvandessel/feedback-loop/internal/activation"
-	"github.com/nvandessel/feedback-loop/internal/backup"
 	"github.com/nvandessel/feedback-loop/internal/assembly"
+	"github.com/nvandessel/feedback-loop/internal/backup"
 	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/dedup"
 	"github.com/nvandessel/feedback-loop/internal/learning"
 	"github.com/nvandessel/feedback-loop/internal/models"
+	"github.com/nvandessel/feedback-loop/internal/pathutil"
 	"github.com/nvandessel/feedback-loop/internal/ranking"
 	"github.com/nvandessel/feedback-loop/internal/spreading"
 	"github.com/nvandessel/feedback-loop/internal/store"
@@ -766,11 +767,21 @@ func (s *Server) handleFloopDeduplicate(ctx context.Context, req *sdk.CallToolRe
 func (s *Server) handleFloopBackup(ctx context.Context, req *sdk.CallToolRequest, args FloopBackupInput) (*sdk.CallToolResult, FloopBackupOutput, error) {
 	outputPath := args.OutputPath
 	if outputPath == "" {
+		// Default path -- controlled by us, no validation needed
 		backupDir, err := backup.DefaultBackupDir()
 		if err != nil {
 			return nil, FloopBackupOutput{}, fmt.Errorf("failed to get backup directory: %w", err)
 		}
 		outputPath = backup.GenerateBackupPath(backupDir)
+	} else {
+		// User-specified path -- validate against allowed directories
+		allowedDirs, err := pathutil.DefaultAllowedBackupDirsWithProjectRoot(s.root)
+		if err != nil {
+			return nil, FloopBackupOutput{}, fmt.Errorf("failed to determine allowed backup dirs: %w", err)
+		}
+		if err := pathutil.ValidatePath(outputPath, allowedDirs); err != nil {
+			return nil, FloopBackupOutput{}, fmt.Errorf("backup path rejected: %w", err)
+		}
 	}
 
 	result, err := backup.Backup(ctx, s.store, outputPath)
@@ -796,6 +807,15 @@ func (s *Server) handleFloopBackup(ctx context.Context, req *sdk.CallToolRequest
 func (s *Server) handleFloopRestore(ctx context.Context, req *sdk.CallToolRequest, args FloopRestoreInput) (*sdk.CallToolResult, FloopRestoreOutput, error) {
 	if args.InputPath == "" {
 		return nil, FloopRestoreOutput{}, fmt.Errorf("'input_path' parameter is required")
+	}
+
+	// Validate user-supplied path against allowed directories
+	allowedDirs, err := pathutil.DefaultAllowedBackupDirsWithProjectRoot(s.root)
+	if err != nil {
+		return nil, FloopRestoreOutput{}, fmt.Errorf("failed to determine allowed backup dirs: %w", err)
+	}
+	if err := pathutil.ValidatePath(args.InputPath, allowedDirs); err != nil {
+		return nil, FloopRestoreOutput{}, fmt.Errorf("restore path rejected: %w", err)
 	}
 
 	mode := backup.RestoreMerge

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -118,10 +118,10 @@ type FloopBackupInput struct {
 
 // FloopBackupOutput defines the output for floop_backup tool.
 type FloopBackupOutput struct {
-	Path       string `json:"path" jsonschema:"Path to the backup file"`
-	NodeCount  int    `json:"node_count" jsonschema:"Number of nodes backed up"`
-	EdgeCount  int    `json:"edge_count" jsonschema:"Number of edges backed up"`
-	Message    string `json:"message" jsonschema:"Human-readable result message"`
+	Path      string `json:"path" jsonschema:"Path to the backup file"`
+	NodeCount int    `json:"node_count" jsonschema:"Number of nodes backed up"`
+	EdgeCount int    `json:"edge_count" jsonschema:"Number of edges backed up"`
+	Message   string `json:"message" jsonschema:"Human-readable result message"`
 }
 
 // FloopRestoreInput defines the input for floop_restore tool.

--- a/internal/pathutil/validate.go
+++ b/internal/pathutil/validate.go
@@ -1,0 +1,124 @@
+// Package pathutil provides path validation utilities for securing file operations.
+package pathutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ValidatePath checks that a file path is within one of the allowed directories.
+// It resolves symlinks, cleans the path, and rejects traversal attempts.
+func ValidatePath(path string, allowedDirs []string) error {
+	if path == "" {
+		return fmt.Errorf("path validation failed: path is empty")
+	}
+
+	if len(allowedDirs) == 0 {
+		return fmt.Errorf("path validation failed: no allowed directories configured")
+	}
+
+	// Check for null bytes (common injection vector)
+	if strings.ContainsRune(path, '\x00') {
+		return fmt.Errorf("path validation failed: path contains null byte")
+	}
+
+	// Clean and make absolute
+	cleaned := filepath.Clean(path)
+	absPath, err := filepath.Abs(cleaned)
+	if err != nil {
+		return fmt.Errorf("path validation failed: cannot resolve absolute path: %w", err)
+	}
+
+	// Resolve symlinks on the parent directory (the file itself may not exist yet).
+	// This prevents symlink-based escapes where a directory inside the allowed
+	// tree is actually a symlink pointing outside.
+	dir := filepath.Dir(absPath)
+	resolvedDir, err := resolveExistingParent(dir)
+	if err != nil {
+		return fmt.Errorf("path validation failed: cannot resolve parent directory: %w", err)
+	}
+
+	// Reconstruct the full resolved path
+	resolvedPath := filepath.Join(resolvedDir, filepath.Base(absPath))
+
+	// Check that the resolved path is inside one of the allowed directories
+	for _, allowed := range allowedDirs {
+		allowedClean := filepath.Clean(allowed)
+		allowedAbs, err := filepath.Abs(allowedClean)
+		if err != nil {
+			continue
+		}
+		// Also resolve symlinks in the allowed directory itself
+		allowedResolved, err := resolveExistingParent(allowedAbs)
+		if err != nil {
+			continue
+		}
+
+		if isSubpath(resolvedPath, allowedResolved) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("path validation failed: %q is outside allowed directories", absPath)
+}
+
+// resolveExistingParent walks up the directory tree to find the deepest existing
+// ancestor, resolves symlinks on it, then re-appends the non-existent tail.
+// This handles cases where the target file or some parent directories don't exist yet.
+func resolveExistingParent(dir string) (string, error) {
+	// Try to resolve the full path first
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err == nil {
+		return resolved, nil
+	}
+
+	// Walk up until we find an existing directory
+	parent := filepath.Dir(dir)
+	if parent == dir {
+		// We've hit the root and it doesn't exist -- give up
+		return "", fmt.Errorf("cannot resolve path: %s", dir)
+	}
+
+	resolvedParent, err := resolveExistingParent(parent)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(resolvedParent, filepath.Base(dir)), nil
+}
+
+// isSubpath checks whether path is equal to or a subdirectory of base.
+func isSubpath(path, base string) bool {
+	if path == base {
+		return true
+	}
+	// Ensure base ends with separator so "/tmp/foo" doesn't match "/tmp/foobar"
+	prefix := base + string(os.PathSeparator)
+	return strings.HasPrefix(path, prefix)
+}
+
+// DefaultAllowedBackupDirs returns the directories where backups are allowed.
+// Returns: ~/.floop/backups/
+func DefaultAllowedBackupDirs() ([]string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %w", err)
+	}
+	return []string{
+		filepath.Join(homeDir, ".floop", "backups"),
+	}, nil
+}
+
+// DefaultAllowedBackupDirsWithProjectRoot returns the directories where backups
+// are allowed, including a project-local directory.
+// Returns: ~/.floop/backups/ and <projectRoot>/.floop/backups/
+func DefaultAllowedBackupDirsWithProjectRoot(projectRoot string) ([]string, error) {
+	dirs, err := DefaultAllowedBackupDirs()
+	if err != nil {
+		return nil, err
+	}
+	dirs = append(dirs, filepath.Join(projectRoot, ".floop", "backups"))
+	return dirs, nil
+}

--- a/internal/pathutil/validate_test.go
+++ b/internal/pathutil/validate_test.go
@@ -1,0 +1,210 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestValidatePath(t *testing.T) {
+	// Create temp dirs to use as allowed dirs
+	allowedDir := t.TempDir()
+	otherDir := t.TempDir()
+
+	// Create a subdirectory inside the allowed dir
+	subDir := filepath.Join(allowedDir, "subdir")
+	if err := os.MkdirAll(subDir, 0700); err != nil {
+		t.Fatalf("failed to create subdir: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		path        string
+		allowedDirs []string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "valid path inside allowed dir",
+			path:        filepath.Join(allowedDir, "backup.json"),
+			allowedDirs: []string{allowedDir},
+			wantErr:     false,
+		},
+		{
+			name:        "valid path in subdirectory of allowed dir",
+			path:        filepath.Join(subDir, "backup.json"),
+			allowedDirs: []string{allowedDir},
+			wantErr:     false,
+		},
+		{
+			name:        "path that is exactly the allowed dir",
+			path:        allowedDir,
+			allowedDirs: []string{allowedDir},
+			wantErr:     false,
+		},
+		{
+			name:        "path traversal with dot-dot",
+			path:        filepath.Join(allowedDir, "..", "etc", "passwd"),
+			allowedDirs: []string{allowedDir},
+			wantErr:     true,
+			errContains: "outside allowed directories",
+		},
+		{
+			name:        "absolute path outside allowed dir",
+			path:        filepath.Join(otherDir, "backup.json"),
+			allowedDirs: []string{allowedDir},
+			wantErr:     true,
+			errContains: "outside allowed directories",
+		},
+		{
+			name:        "null bytes in path",
+			path:        filepath.Join(allowedDir, "back\x00up.json"),
+			allowedDirs: []string{allowedDir},
+			wantErr:     true,
+			errContains: "null byte",
+		},
+		{
+			name:        "path with redundant separators is cleaned",
+			path:        allowedDir + string(os.PathSeparator) + string(os.PathSeparator) + "backup.json",
+			allowedDirs: []string{allowedDir},
+			wantErr:     false,
+		},
+		{
+			name:        "empty path",
+			path:        "",
+			allowedDirs: []string{allowedDir},
+			wantErr:     true,
+			errContains: "empty",
+		},
+		{
+			name:        "no allowed dirs",
+			path:        filepath.Join(allowedDir, "backup.json"),
+			allowedDirs: []string{},
+			wantErr:     true,
+			errContains: "no allowed directories",
+		},
+		{
+			name:        "multiple allowed dirs - matches second",
+			path:        filepath.Join(otherDir, "backup.json"),
+			allowedDirs: []string{allowedDir, otherDir},
+			wantErr:     false,
+		},
+		{
+			name:        "path traversal with embedded dot-dot",
+			path:        filepath.Join(allowedDir, "subdir", "..", "..", "etc", "passwd"),
+			allowedDirs: []string{allowedDir},
+			wantErr:     true,
+			errContains: "outside allowed directories",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidatePath(tt.path, tt.allowedDirs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidatePath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.errContains != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("ValidatePath() error = %v, want error containing %q", err, tt.errContains)
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePath_SymlinkOutsideAllowedDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on Windows")
+	}
+
+	allowedDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	// Create a symlink inside the allowed dir that points outside
+	symlinkPath := filepath.Join(allowedDir, "escape")
+	if err := os.Symlink(outsideDir, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	// A path through the symlink should be rejected
+	err := ValidatePath(filepath.Join(symlinkPath, "backup.json"), []string{allowedDir})
+	if err == nil {
+		t.Error("ValidatePath() should reject symlink pointing outside allowed dir")
+	}
+	if err != nil && !strings.Contains(err.Error(), "outside allowed directories") {
+		t.Errorf("ValidatePath() error = %v, want error about outside allowed directories", err)
+	}
+}
+
+func TestValidatePath_SymlinkInsideAllowedDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test not supported on Windows")
+	}
+
+	allowedDir := t.TempDir()
+
+	// Create a subdirectory and a symlink to it (both inside allowed dir)
+	realSubDir := filepath.Join(allowedDir, "real")
+	if err := os.MkdirAll(realSubDir, 0700); err != nil {
+		t.Fatalf("failed to create real subdir: %v", err)
+	}
+
+	symlinkPath := filepath.Join(allowedDir, "link")
+	if err := os.Symlink(realSubDir, symlinkPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	// A path through a symlink that stays inside allowed dir should be OK
+	err := ValidatePath(filepath.Join(symlinkPath, "backup.json"), []string{allowedDir})
+	if err != nil {
+		t.Errorf("ValidatePath() should accept symlink staying inside allowed dir, got: %v", err)
+	}
+}
+
+func TestDefaultAllowedBackupDirs(t *testing.T) {
+	dirs, err := DefaultAllowedBackupDirs()
+	if err != nil {
+		t.Fatalf("DefaultAllowedBackupDirs() error = %v", err)
+	}
+
+	if len(dirs) == 0 {
+		t.Fatal("DefaultAllowedBackupDirs() returned no directories")
+	}
+
+	// First directory should be ~/.floop/backups/
+	homeDir, _ := os.UserHomeDir()
+	expectedGlobal := filepath.Join(homeDir, ".floop", "backups")
+	if dirs[0] != expectedGlobal {
+		t.Errorf("dirs[0] = %s, want %s", dirs[0], expectedGlobal)
+	}
+}
+
+func TestDefaultAllowedBackupDirsWithProjectRoot(t *testing.T) {
+	projectRoot := t.TempDir()
+
+	dirs, err := DefaultAllowedBackupDirsWithProjectRoot(projectRoot)
+	if err != nil {
+		t.Fatalf("DefaultAllowedBackupDirsWithProjectRoot() error = %v", err)
+	}
+
+	if len(dirs) < 2 {
+		t.Fatalf("expected at least 2 directories, got %d", len(dirs))
+	}
+
+	// Should include the project-local .floop/backups/ dir
+	expectedLocal := filepath.Join(projectRoot, ".floop", "backups")
+	found := false
+	for _, d := range dirs {
+		if d == expectedLocal {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("dirs should contain %s, got %v", expectedLocal, dirs)
+	}
+}


### PR DESCRIPTION
## Summary
- **Severity:** HIGH
- Adds `internal/pathutil/` package with `ValidatePath()` for path containment checking
- Backup/restore paths constrained to `~/.floop/backups/` and project-local `.floop/backups/`
- Rejects path traversal (`../`), null bytes, and symlinks pointing outside allowed dirs
- File permissions hardened: dirs 0700, files 0600 (was 0755/0644)
- Applied at both MCP handler layer and CLI command layer

## Test plan
- [ ] `go test ./internal/pathutil/...` — 15 tests including symlink attack scenarios
- [ ] `go test ./internal/backup/...` — 4 new tests for validation + permissions
- [ ] `go test ./internal/mcp/...` — e2e test updated for new path constraints
- [ ] `go test ./...` — full suite passes (20 packages)
- [ ] Manual: `floop backup --output /etc/evil.json` → verify rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)