### PR TITLE
feat: add tag filtering to floop_list MCP tool and CLI

### DIFF
--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -825,6 +825,35 @@ func TestBuildSpreadIndex_UsesSpreadResults(t *testing.T) {
 	}
 }
 
+func TestBehaviorContentToMap_IncludesTags(t *testing.T) {
+	content := models.BehaviorContent{
+		Canonical: "test behavior",
+		Tags:      []string{"git", "workflow"},
+	}
+
+	m := behaviorContentToMap(content)
+
+	tags, ok := m["tags"].([]string)
+	if !ok {
+		t.Fatal("expected tags in content map")
+	}
+	if len(tags) != 2 || tags[0] != "git" || tags[1] != "workflow" {
+		t.Errorf("tags = %v, want [git workflow]", tags)
+	}
+}
+
+func TestBehaviorContentToMap_OmitsEmptyTags(t *testing.T) {
+	content := models.BehaviorContent{
+		Canonical: "test behavior",
+	}
+
+	m := behaviorContentToMap(content)
+
+	if _, ok := m["tags"]; ok {
+		t.Error("expected tags to be omitted when empty")
+	}
+}
+
 func TestHandleBehaviorsResource_EmptyStoreFraming(t *testing.T) {
 	server, _ := setupTestServer(t)
 	defer server.Close()

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -26,6 +26,7 @@ type BehaviorSummary struct {
 	Content    map[string]interface{} `json:"content"`
 	Confidence float64                `json:"confidence"`
 	When       map[string]interface{} `json:"when,omitempty"`
+	Tags       []string               `json:"tags,omitempty"`
 	Activation float64                `json:"activation,omitempty"`
 	Distance   int                    `json:"distance,omitempty"`
 	SeedSource string                 `json:"seed_source,omitempty"`
@@ -55,7 +56,8 @@ type FloopLearnOutput struct {
 
 // FloopListInput defines the input for floop_list tool.
 type FloopListInput struct {
-	Corrections bool `json:"corrections,omitempty" jsonschema:"List corrections instead of behaviors (default: false)"`
+	Corrections bool   `json:"corrections,omitempty" jsonschema:"List corrections instead of behaviors (default: false)"`
+	Tag         string `json:"tag,omitempty" jsonschema:"Filter behaviors by tag (exact match)"`
 }
 
 // FloopListOutput defines the output for floop_list tool.
@@ -71,6 +73,7 @@ type BehaviorListItem struct {
 	Name       string    `json:"name"`
 	Kind       string    `json:"kind"`
 	Confidence float64   `json:"confidence"`
+	Tags       []string  `json:"tags,omitempty"`
 	Source     string    `json:"source"`
 	CreatedAt  time.Time `json:"created_at"`
 }


### PR DESCRIPTION
## Summary
- Expose existing `tags` field in `BehaviorSummary` and `BehaviorListItem` MCP output types
- Add `--tag` filter flag to `floop list` CLI command
- Add `tag` filter parameter to `floop_list` MCP tool
- Include tags in `behaviorContentToMap` output

## Test plan
- [ ] `go test ./internal/mcp/...` — tag content map tests
- [ ] `floop list --tag git` — filters by tag
- [ ] `floop list` — shows tags in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)