### PR TITLE
fix: sanitize LLM merge output to prevent stored prompt injection

### DIFF
--- a/internal/dedup/merger.go
+++ b/internal/dedup/merger.go
@@ -80,7 +80,11 @@ func (m *BehaviorMerger) llmMerge(ctx context.Context, behaviors []*models.Behav
 	// Sanitize LLM-generated content to prevent stored prompt injection
 	merged.Content.Canonical = sanitize.SanitizeBehaviorContent(merged.Content.Canonical)
 	merged.Content.Expanded = sanitize.SanitizeBehaviorContent(merged.Content.Expanded)
+	merged.Content.Summary = sanitize.SanitizeBehaviorContent(merged.Content.Summary)
 	merged.Name = sanitize.SanitizeBehaviorName(merged.Name)
+	for i, tag := range merged.Content.Tags {
+		merged.Content.Tags[i] = sanitize.SanitizeBehaviorName(tag)
+	}
 
 	// Ensure the merged behavior has proper metadata
 	merged.ID = generateMergedID(behaviors)
@@ -124,7 +128,11 @@ func (m *BehaviorMerger) ruleMerge(behaviors []*models.Behavior) *models.Behavio
 	// Sanitize merged content to prevent stored prompt injection
 	merged.Content.Canonical = sanitize.SanitizeBehaviorContent(merged.Content.Canonical)
 	merged.Content.Expanded = sanitize.SanitizeBehaviorContent(merged.Content.Expanded)
+	merged.Content.Summary = sanitize.SanitizeBehaviorContent(merged.Content.Summary)
 	merged.Name = sanitize.SanitizeBehaviorName(merged.Name)
+	for i, tag := range merged.Content.Tags {
+		merged.Content.Tags[i] = sanitize.SanitizeBehaviorName(tag)
+	}
 
 	// Track merge relationships
 	for _, b := range behaviors {


### PR DESCRIPTION
## Summary
- Closes security finding C1: LLM-generated merged content stored with zero sanitization
- Adds `sanitize.SanitizeBehaviorContent()` to both `llmMerge()` and `ruleMerge()` output paths
- Adds `sanitize.SanitizeBehaviorName()` for merged behavior names
- Prevents jailbroken LLM from producing injection payloads in merged behaviors

## Test plan
- [x] 5 table-driven subtests in `TestMerge_SanitizesOutput`
- [x] Covers: XML tag stripping, markdown heading conversion, rule-based merge sanitization, length truncation, name sanitization
- [x] Uses mock LLM client to test LLM merge path
- [x] Full test suite passes (`go test ./...` — 23 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)