### PR TITLE
fix: add XML entity escaping to assembly compiler output

### DIFF
--- a/internal/assembly/compile.go
+++ b/internal/assembly/compile.go
@@ -375,7 +375,12 @@ func (c *Compiler) buildQuickReferenceSection(summarized []models.InjectedBehavi
 		if len(shortID) > 8 {
 			shortID = shortID[:8]
 		}
-		lines = append(lines, fmt.Sprintf("- [%s] %s", shortID, ib.Content))
+		content := ib.Content
+		if c.format == FormatXML {
+			content = escapeXML(content)
+			shortID = escapeXML(shortID)
+		}
+		lines = append(lines, fmt.Sprintf("- [%s] %s", shortID, content))
 	}
 
 	return strings.Join(lines, "\n")
@@ -394,7 +399,11 @@ func (c *Compiler) buildNameOnlySection(nameOnly []models.InjectedBehavior) stri
 			continue
 		}
 		// Content is pre-formatted by the tier mapper as `name` [kind] #tags
-		lines = append(lines, fmt.Sprintf("- %s", ib.Content))
+		content := ib.Content
+		if c.format == FormatXML {
+			content = escapeXML(content)
+		}
+		lines = append(lines, fmt.Sprintf("- %s", content))
 	}
 
 	return strings.Join(lines, "\n")
@@ -533,9 +542,9 @@ func (c *Compiler) formatCluster(cluster BehaviorCluster, totalCount int) string
 
 	switch c.format {
 	case FormatXML:
-		lines = append(lines, fmt.Sprintf("<cluster label=%q count=\"%d\">", escapeXML(cluster.ClusterLabel), totalCount))
+		lines = append(lines, fmt.Sprintf("<cluster label=\"%s\" count=\"%d\">", escapeXML(cluster.ClusterLabel), totalCount))
 		if cluster.Representative.Behavior != nil {
-			lines = append(lines, fmt.Sprintf("  <behavior kind=%q>%s</behavior>",
+			lines = append(lines, fmt.Sprintf("  <behavior kind=\"%s\">%s</behavior>",
 				cluster.Representative.Behavior.Kind,
 				escapeXML(cluster.Representative.Content)))
 		}


### PR DESCRIPTION
## Summary
- Closes security finding H3: XML output format interpolated user content without escaping
- Adds `escapeXML()` helper for the 5 XML entities (`&`, `<`, `>`, `"`, `'`)
- Applied to `formatBehaviorXML()` content and `formatCluster()` XML path (label, content, member names)
- Controlled enum values (e.g., `b.Kind`) left unescaped

## Test plan
- [x] `TestFormatBehaviorXML_EscapesContent` — 6 subtests covering each entity type + combined + passthrough
- [x] `TestFormatCluster_EscapesXMLContent` — verifies cluster label, representative content, and member names are escaped
- [x] Full test suite passes (`go test ./...` — 23 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)