### PR TITLE
fix: harden shell hooks against symlink and TOCTOU attacks

### DIFF
--- a/.claude/hooks/first-prompt-inject.sh
+++ b/.claude/hooks/first-prompt-inject.sh
@@ -4,13 +4,13 @@
 
 INPUT=$(cat)
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // "unknown"')
-MARKER="/tmp/floop-session-$SESSION_ID"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+MARKER="${RUNTIME_DIR}/floop-session-${SESSION_ID}"
 
-# Only run once per session
-if [ -f "$MARKER" ]; then
+# Only run once per session (atomic mkdir fails if dir already exists, avoiding TOCTOU race)
+if ! mkdir "$MARKER" 2>/dev/null; then
     exit 0
 fi
-touch "$MARKER"
 
 FLOOP_CMD="${CLAUDE_PROJECT_DIR}/floop"
 


### PR DESCRIPTION
## Summary
- Use `${XDG_RUNTIME_DIR:-/tmp}` for session marker paths instead of hardcoded `/tmp`
- Replace TOCTOU `[ -f ] && touch` with atomic `mkdir` for session-once guard
- Verify all `$FLOOP_CMD` references are properly quoted (confirmed already correct)

Addresses: feedback-loop-w03.5

## Test plan
- [ ] `bash -n` syntax check passes on all 4 hook scripts
- [ ] Session marker uses XDG_RUNTIME_DIR when set
- [ ] Atomic mkdir prevents race conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)