### PR TITLE
fix: redact paths in error messages and prevent API key leakage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,6 +53,26 @@ type LLMConfig struct {
 	FallbackToRules bool `json:"fallback_to_rules" yaml:"fallback_to_rules"`
 }
 
+// RedactedAPIKey returns the API key with most characters masked.
+// Shows first 4 and last 4 characters, e.g., "sk-a...xyz9".
+// Returns "" for empty keys and "(set)" for keys shorter than 12 chars.
+func (c LLMConfig) RedactedAPIKey() string {
+	if c.APIKey == "" {
+		return ""
+	}
+	if len(c.APIKey) < 12 {
+		return "(set)"
+	}
+	return c.APIKey[:4] + "..." + c.APIKey[len(c.APIKey)-4:]
+}
+
+// String implements fmt.Stringer to prevent accidental API key logging.
+// It returns a representation with the API key redacted.
+func (c LLMConfig) String() string {
+	return fmt.Sprintf("LLMConfig{Provider:%s, Enabled:%t, APIKey:%s, Model:%s}",
+		c.Provider, c.Enabled, c.RedactedAPIKey(), c.ComparisonModel)
+}
+
 // DeduplicationConfig configures behavior deduplication.
 type DeduplicationConfig struct {
 	// AutoMerge enables automatic merging of detected duplicates.

--- a/internal/pathutil/validate_test.go
+++ b/internal/pathutil/validate_test.go
@@ -165,6 +165,30 @@ func TestValidatePath_SymlinkInsideAllowedDir(t *testing.T) {
 	}
 }
 
+func TestRedactPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"simple", "/home/user/.floop/config.yaml", ".../.floop/config.yaml"},
+		{"deep", "/a/b/c/d/e.txt", ".../d/e.txt"},
+		{"root file", "/file.txt", "file.txt"},
+		{"relative", "dir/file.txt", ".../dir/file.txt"},
+		{"just filename", "file.txt", "file.txt"},
+		{"trailing slash cleaned", "/home/user/.floop/", ".../user/.floop"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := RedactPath(tt.input)
+			if got != tt.want {
+				t.Errorf("RedactPath(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDefaultAllowedBackupDirs(t *testing.T) {
 	dirs, err := DefaultAllowedBackupDirs()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `RedactPath()` utility to `pathutil` package that reduces full filesystem paths to `.../<parent>/<basename>` in error messages, preventing directory structure leakage
- Add `RedactedAPIKey()` method to `LLMConfig` that masks API keys (shows first 4 + last 4 chars), with safe handling of empty and short keys
- Add `String()` method implementing `fmt.Stringer` on `LLMConfig` to prevent accidental full API key logging via `fmt.Print`/`%v`/`%s`
- Update `ValidatePath` and `resolveExistingParent` error messages to use redacted paths

Addresses: feedback-loop-w03.12

## Test plan
- [x] `TestRedactPath` — empty, simple, deep, root file, relative, just filename, trailing slash edge cases
- [x] `TestRedactedAPIKey` — empty key, short key, boundary (11/12 chars), normal key
- [x] `TestLLMConfigString` — verifies String() does not contain full API key, contains redacted version
- [x] `go test ./...` — all 23 packages pass
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)