### PR TITLE
fix: add confidence manipulation defenses with boost rate limiting

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -391,7 +391,7 @@ func (s *Server) handleFloopActive(ctx context.Context, req *sdk.CallToolRequest
 		}
 		if updater, ok := s.store.(confidenceUpdater); ok {
 			cfg := ranking.DefaultReinforcementConfig()
-			if err := ranking.ApplyReinforcement(context.Background(), updater, activeConfs, allConfs, cfg); err != nil {
+			if err := ranking.ApplyReinforcement(context.Background(), updater, activeConfs, allConfs, cfg, s.boostTracker); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: confidence reinforcement failed: %v\n", err)
 			}
 		}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -32,6 +32,9 @@ type Server struct {
 	// Rate limiting
 	toolLimiters ratelimit.ToolLimiters
 
+	// Confidence boost rate limiting
+	boostTracker *ranking.BoostTracker
+
 	// PageRank debounce
 	pageRankDebounce   *time.Timer
 	pageRankDebounceMu sync.Mutex
@@ -76,6 +79,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		session:       session.NewState(session.DefaultConfig()),
 		pageRankCache: make(map[string]float64),
 		toolLimiters:  ratelimit.NewToolLimiters(),
+		boostTracker:  ranking.DefaultBoostTracker(),
 		workerPool:    make(chan struct{}, maxBackgroundWorkers),
 		done:          make(chan struct{}),
 	}

--- a/internal/ranking/reinforcement.go
+++ b/internal/ranking/reinforcement.go
@@ -4,6 +4,8 @@ package ranking
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 )
 
 // ConfidenceReinforcementConfig configures the confidence reinforcement parameters.
@@ -14,7 +16,7 @@ type ConfidenceReinforcementConfig struct {
 	DecayAmount float64
 	// Ceiling is the maximum confidence value (0.95 default).
 	Ceiling float64
-	// Floor is the minimum confidence value (0.6 default).
+	// Floor is the minimum confidence value (0.3 default).
 	Floor float64
 }
 
@@ -24,7 +26,7 @@ func DefaultReinforcementConfig() ConfidenceReinforcementConfig {
 		BoostAmount: 0.02,
 		DecayAmount: 0.005,
 		Ceiling:     0.95,
-		Floor:       0.6,
+		Floor:       0.3,
 	}
 }
 
@@ -33,16 +35,73 @@ type ConfidenceUpdater interface {
 	UpdateConfidence(ctx context.Context, behaviorID string, newConfidence float64) error
 }
 
+// BoostTracker limits how many confidence boosts a behavior can receive within a time window.
+// A nil BoostTracker means no rate limiting (backward-compatible).
+type BoostTracker struct {
+	mu         sync.Mutex
+	maxBoosts  int
+	window     time.Duration
+	boostTimes map[string][]time.Time // behaviorID -> list of boost timestamps
+}
+
+// NewBoostTracker creates a BoostTracker with the given limits.
+func NewBoostTracker(maxBoosts int, window time.Duration) *BoostTracker {
+	return &BoostTracker{
+		maxBoosts:  maxBoosts,
+		window:     window,
+		boostTimes: make(map[string][]time.Time),
+	}
+}
+
+// DefaultBoostTracker returns a tracker allowing 3 boosts per hour.
+func DefaultBoostTracker() *BoostTracker {
+	return NewBoostTracker(3, time.Hour)
+}
+
+// AllowBoost checks if a behavior is allowed to be boosted.
+// Returns true if under the rate limit, false if rate limited.
+// When it returns true, it records the boost.
+func (bt *BoostTracker) AllowBoost(behaviorID string) bool {
+	bt.mu.Lock()
+	defer bt.mu.Unlock()
+
+	now := time.Now()
+	cutoff := now.Add(-bt.window)
+
+	// Filter to only recent boosts within the window
+	times := bt.boostTimes[behaviorID]
+	recent := make([]time.Time, 0, len(times))
+	for _, t := range times {
+		if t.After(cutoff) {
+			recent = append(recent, t)
+		}
+	}
+
+	if len(recent) >= bt.maxBoosts {
+		bt.boostTimes[behaviorID] = recent
+		return false
+	}
+
+	bt.boostTimes[behaviorID] = append(recent, now)
+	return true
+}
+
 // ApplyReinforcement adjusts confidence for active and inactive behaviors.
 // Active behaviors get a boost; all other behaviors decay slightly.
-func ApplyReinforcement(ctx context.Context, updater ConfidenceUpdater, activeIDs map[string]float64, allIDs map[string]float64, cfg ConfidenceReinforcementConfig) error {
+// If tracker is non-nil, boosts are rate-limited per behavior.
+// A nil tracker disables rate limiting (backward-compatible).
+func ApplyReinforcement(ctx context.Context, updater ConfidenceUpdater, activeIDs map[string]float64, allIDs map[string]float64, cfg ConfidenceReinforcementConfig, tracker *BoostTracker) error {
 	for id, currentConf := range allIDs {
 		var newConf float64
 		if _, isActive := activeIDs[id]; isActive {
-			// Boost active behaviors
-			newConf = currentConf + cfg.BoostAmount
-			if newConf > cfg.Ceiling {
-				newConf = cfg.Ceiling
+			// Check rate limit before boosting
+			if tracker == nil || tracker.AllowBoost(id) {
+				newConf = currentConf + cfg.BoostAmount
+				if newConf > cfg.Ceiling {
+					newConf = cfg.Ceiling
+				}
+			} else {
+				newConf = currentConf // Rate limited, no change
 			}
 		} else {
 			// Decay inactive behaviors

--- a/internal/ranking/reinforcement_test.go
+++ b/internal/ranking/reinforcement_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"testing"
+	"time"
 )
 
 const floatEpsilon = 1e-9
@@ -34,7 +35,7 @@ func TestApplyReinforcement_Boost(t *testing.T) {
 	activeIDs := map[string]float64{"b1": 0.7}
 	allIDs := map[string]float64{"b1": 0.7}
 
-	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg)
+	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, nil)
 	if err != nil {
 		t.Fatalf("ApplyReinforcement() error = %v", err)
 	}
@@ -52,7 +53,7 @@ func TestApplyReinforcement_Decay(t *testing.T) {
 	activeIDs := map[string]float64{} // b1 is NOT active
 	allIDs := map[string]float64{"b1": 0.7}
 
-	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg)
+	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, nil)
 	if err != nil {
 		t.Fatalf("ApplyReinforcement() error = %v", err)
 	}
@@ -70,7 +71,7 @@ func TestApplyReinforcement_Ceiling(t *testing.T) {
 	activeIDs := map[string]float64{"b1": 0.94}
 	allIDs := map[string]float64{"b1": 0.94}
 
-	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg)
+	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, nil)
 	if err != nil {
 		t.Fatalf("ApplyReinforcement() error = %v", err)
 	}
@@ -86,9 +87,9 @@ func TestApplyReinforcement_Floor(t *testing.T) {
 	ctx := context.Background()
 
 	activeIDs := map[string]float64{} // b1 is NOT active
-	allIDs := map[string]float64{"b1": 0.6}
+	allIDs := map[string]float64{"b1": 0.3}
 
-	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg)
+	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, nil)
 	if err != nil {
 		t.Fatalf("ApplyReinforcement() error = %v", err)
 	}
@@ -107,7 +108,7 @@ func TestApplyReinforcement_MixedSet(t *testing.T) {
 	activeIDs := map[string]float64{"b1": 0.7, "b3": 0.8}
 	allIDs := map[string]float64{"b1": 0.7, "b2": 0.75, "b3": 0.8}
 
-	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg)
+	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, nil)
 	if err != nil {
 		t.Fatalf("ApplyReinforcement() error = %v", err)
 	}
@@ -133,12 +134,218 @@ func TestApplyReinforcement_EmptySets(t *testing.T) {
 	updater := newMockUpdater()
 	ctx := context.Background()
 
-	err := ApplyReinforcement(ctx, updater, map[string]float64{}, map[string]float64{}, cfg)
+	err := ApplyReinforcement(ctx, updater, map[string]float64{}, map[string]float64{}, cfg, nil)
 	if err != nil {
 		t.Fatalf("ApplyReinforcement() error = %v", err)
 	}
 
 	if len(updater.updates) != 0 {
 		t.Errorf("expected no updates for empty sets, got %d", len(updater.updates))
+	}
+}
+
+func TestDefaultReinforcementConfig_FloorIs03(t *testing.T) {
+	cfg := DefaultReinforcementConfig()
+	if cfg.Floor != 0.3 {
+		t.Errorf("DefaultReinforcementConfig().Floor = %v, want 0.3", cfg.Floor)
+	}
+}
+
+func TestApplyReinforcement_DecayBelowOldFloor(t *testing.T) {
+	cfg := DefaultReinforcementConfig()
+	updater := newMockUpdater()
+	ctx := context.Background()
+
+	// Start at 0.5, which is below the old floor of 0.6 but above the new floor of 0.3
+	activeIDs := map[string]float64{}
+	allIDs := map[string]float64{"b1": 0.5}
+
+	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, nil)
+	if err != nil {
+		t.Fatalf("ApplyReinforcement() error = %v", err)
+	}
+
+	// Should decay to 0.495 (below old 0.6 floor)
+	if !floatEquals(updater.updates["b1"], 0.495) {
+		t.Errorf("b1 confidence = %v, want 0.495", updater.updates["b1"])
+	}
+}
+
+func TestBoostTracker_AllowBoost(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxBoosts  int
+		window     time.Duration
+		boostCount int
+		wantAllow  bool
+	}{
+		{
+			name:       "first boost allowed",
+			maxBoosts:  3,
+			window:     time.Hour,
+			boostCount: 0,
+			wantAllow:  true,
+		},
+		{
+			name:       "second boost allowed",
+			maxBoosts:  3,
+			window:     time.Hour,
+			boostCount: 1,
+			wantAllow:  true,
+		},
+		{
+			name:       "third boost allowed",
+			maxBoosts:  3,
+			window:     time.Hour,
+			boostCount: 2,
+			wantAllow:  true,
+		},
+		{
+			name:       "fourth boost rate limited",
+			maxBoosts:  3,
+			window:     time.Hour,
+			boostCount: 3,
+			wantAllow:  false,
+		},
+		{
+			name:       "single boost limit exceeded",
+			maxBoosts:  1,
+			window:     time.Hour,
+			boostCount: 1,
+			wantAllow:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bt := NewBoostTracker(tt.maxBoosts, tt.window)
+			// Pre-fill boosts
+			for range tt.boostCount {
+				bt.AllowBoost("b1")
+			}
+			got := bt.AllowBoost("b1")
+			if got != tt.wantAllow {
+				t.Errorf("AllowBoost() = %v, want %v", got, tt.wantAllow)
+			}
+		})
+	}
+}
+
+func TestBoostTracker_IndependentBehaviors(t *testing.T) {
+	bt := NewBoostTracker(1, time.Hour)
+
+	// First behavior gets one boost
+	if !bt.AllowBoost("b1") {
+		t.Error("b1 first boost should be allowed")
+	}
+	// b1 is now rate limited
+	if bt.AllowBoost("b1") {
+		t.Error("b1 second boost should be rate limited")
+	}
+	// b2 is independent, should still be allowed
+	if !bt.AllowBoost("b2") {
+		t.Error("b2 first boost should be allowed (independent of b1)")
+	}
+}
+
+func TestBoostTracker_WindowExpiry(t *testing.T) {
+	bt := NewBoostTracker(1, 100*time.Millisecond)
+
+	if !bt.AllowBoost("b1") {
+		t.Fatal("first boost should be allowed")
+	}
+	if bt.AllowBoost("b1") {
+		t.Fatal("second boost should be rate limited")
+	}
+
+	// Wait for the window to expire
+	time.Sleep(150 * time.Millisecond)
+
+	// After the window expires, boost should be allowed again
+	if !bt.AllowBoost("b1") {
+		t.Error("boost should be allowed after window expires")
+	}
+}
+
+func TestDefaultBoostTracker(t *testing.T) {
+	bt := DefaultBoostTracker()
+	if bt.maxBoosts != 3 {
+		t.Errorf("DefaultBoostTracker().maxBoosts = %d, want 3", bt.maxBoosts)
+	}
+	if bt.window != time.Hour {
+		t.Errorf("DefaultBoostTracker().window = %v, want %v", bt.window, time.Hour)
+	}
+}
+
+func TestApplyReinforcement_WithTracker_RateLimitsBoosts(t *testing.T) {
+	cfg := DefaultReinforcementConfig()
+	ctx := context.Background()
+
+	// Tracker that allows only 1 boost per hour
+	tracker := NewBoostTracker(1, time.Hour)
+
+	// First call: boost should be applied
+	updater1 := newMockUpdater()
+	activeIDs := map[string]float64{"b1": 0.7}
+	allIDs := map[string]float64{"b1": 0.7}
+
+	err := ApplyReinforcement(ctx, updater1, activeIDs, allIDs, cfg, tracker)
+	if err != nil {
+		t.Fatalf("first ApplyReinforcement() error = %v", err)
+	}
+	if !floatEquals(updater1.updates["b1"], 0.72) {
+		t.Errorf("first call: b1 confidence = %v, want 0.72", updater1.updates["b1"])
+	}
+
+	// Second call: boost should be rate limited, no update
+	updater2 := newMockUpdater()
+	err = ApplyReinforcement(ctx, updater2, activeIDs, allIDs, cfg, tracker)
+	if err != nil {
+		t.Fatalf("second ApplyReinforcement() error = %v", err)
+	}
+	if _, updated := updater2.updates["b1"]; updated {
+		t.Errorf("second call: b1 should not be updated when rate limited, got %v", updater2.updates["b1"])
+	}
+}
+
+func TestApplyReinforcement_NilTracker_NoRateLimit(t *testing.T) {
+	cfg := DefaultReinforcementConfig()
+	ctx := context.Background()
+
+	activeIDs := map[string]float64{"b1": 0.7}
+	allIDs := map[string]float64{"b1": 0.7}
+
+	// Call many times with nil tracker - should always boost
+	for i := range 10 {
+		updater := newMockUpdater()
+		err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, nil)
+		if err != nil {
+			t.Fatalf("iteration %d: ApplyReinforcement() error = %v", i, err)
+		}
+		if _, updated := updater.updates["b1"]; !updated {
+			t.Errorf("iteration %d: b1 should be updated with nil tracker", i)
+		}
+	}
+}
+
+func TestApplyReinforcement_TrackerDoesNotAffectDecay(t *testing.T) {
+	cfg := DefaultReinforcementConfig()
+	ctx := context.Background()
+
+	// Tracker with very restrictive limit
+	tracker := NewBoostTracker(0, time.Hour)
+
+	updater := newMockUpdater()
+	activeIDs := map[string]float64{} // b1 is NOT active
+	allIDs := map[string]float64{"b1": 0.7}
+
+	err := ApplyReinforcement(ctx, updater, activeIDs, allIDs, cfg, tracker)
+	if err != nil {
+		t.Fatalf("ApplyReinforcement() error = %v", err)
+	}
+
+	// Decay should still work even with tracker
+	if !floatEquals(updater.updates["b1"], 0.695) {
+		t.Errorf("b1 confidence = %v, want 0.695 (decay should not be affected by tracker)", updater.updates["b1"])
 	}
 }


### PR DESCRIPTION
## Summary
- Lower confidence floor from 0.6 to 0.3 so injected/bad behaviors can decay further
- Add `BoostTracker` with configurable rate limiting (default: 3 boosts/hour/behavior)
- Integrate rate limiting into `ApplyReinforcement` — nil tracker preserves backward compatibility
- Prevents rapid confidence manipulation attacks

Addresses: feedback-loop-w03.7

## Test plan
- [ ] `go test ./internal/ranking/...` passes
- [ ] BoostTracker correctly limits boosts within time window
- [ ] Floor of 0.3 allows behaviors to decay below old 0.6 floor
- [ ] nil tracker means no rate limiting (backward compatible)
- [ ] `go test ./...` passes (all 23 packages)
- [ ] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)