### PR TITLE
fix: harden subagent CLI discovery and prompt passing

### DIFF
--- a/internal/llm/subagent.go
+++ b/internal/llm/subagent.go
@@ -229,7 +229,7 @@ func (c *SubagentClient) isAllowedPath(cliPath string) bool {
 		if err != nil {
 			continue
 		}
-		if strings.HasPrefix(resolved, absDir+string(filepath.Separator)) {
+		if resolved == absDir || strings.HasPrefix(resolved, absDir+string(filepath.Separator)) {
 			return true
 		}
 	}

--- a/internal/llm/subagent_test.go
+++ b/internal/llm/subagent_test.go
@@ -295,6 +295,15 @@ func TestSubagentClient_isAllowedPath_WithRealPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("exact directory match accepted", func(t *testing.T) {
+		// When the resolved path equals the allowed directory exactly,
+		// it should be accepted. This covers the case where the CLI binary
+		// path resolves to exactly the allowed directory path.
+		if !client.isAllowedPath(allowedDir) {
+			t.Errorf("isAllowedPath(%q) = false, want true (exact directory match)", allowedDir)
+		}
+	})
+
 	t.Run("symlink to blocked dir from allowed rejected", func(t *testing.T) {
 		// Create a symlink from allowed dir pointing to blocked dir CLI
 		symlinkPath := filepath.Join(allowedDir, "sneaky-link")


### PR DESCRIPTION
## Summary
- Add `AllowedCLIDirs` config to restrict which directories CLIs can be found in
- Add `validateCLI()` that runs `--version` to verify CLI legitimacy
- Remove overly permissive `ppid > 1` session detection (rely on env vars only)
- Pass prompts via stdin instead of `-p` arg to avoid exposure in process listings

Addresses: feedback-loop-w03.8

## Test plan
- [x] `go test ./internal/llm/...` passes
- [x] `go test ./...` passes (all 24 packages)
- [x] `go vet ./...` passes
- [x] `isAllowedPath` correctly restricts to configured dirs
- [x] `isAllowedPath` resolves symlinks to prevent bypass attacks
- [x] `validateCLI` rejects nonexistent and failing binaries
- [x] ppid-only environment no longer triggers session detection
- [x] Prompt passed via stdin, not command args (verified with mock scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)