### PR TITLE
fix: conflict edges inhibit activation, sanitize when conditions

### DIFF
--- a/internal/spreading/engine.go
+++ b/internal/spreading/engine.go
@@ -138,9 +138,17 @@ func (e *Engine) Activate(ctx context.Context, seeds []Seed) ([]Result, error) {
 				energy := nodeAct * e.config.SpreadFactor * effectiveWeight / outDegree
 				energy *= e.config.DecayFactor
 
-				// Use max, not sum, to prevent runaway activation.
-				if energy > newActivation[neighbor] {
-					newActivation[neighbor] = energy
+				if edge.Kind == "conflicts" {
+					// Conflict edges inhibit: subtract energy from neighbor.
+					newActivation[neighbor] -= energy
+					if newActivation[neighbor] < 0 {
+						newActivation[neighbor] = 0
+					}
+				} else {
+					// Normal edges spread: use max to prevent runaway activation.
+					if energy > newActivation[neighbor] {
+						newActivation[neighbor] = energy
+					}
 				}
 
 				// Track distance and seed source via the shortest path.


### PR DESCRIPTION
## Summary
- Conflict edges now subtract (inhibit) activation energy instead of spreading it in the spreading activation engine, preventing conflicting behaviors from amplifying each other
- Sanitize `when` condition keys and string values during behavior merging using the existing `sanitize` package, closing a stored prompt injection vector
- Add `sanitizeWhenValue` helper for recursive sanitization of condition values (strings, `[]string`, `[]interface{}`)
- Floor inhibited activation at 0 to prevent negative energy values

Addresses: feedback-loop-w03.9

## Test plan
- [x] `go test ./internal/spreading/...` passes with conflict inhibition tests (3 sub-tests)
- [x] `go test ./internal/dedup/...` passes with when-condition sanitization tests (6 sub-tests) and sanitizeWhenValue unit tests (6 sub-tests)
- [x] `go vet ./...` clean
- [x] `go test ./...` all 23 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)