### PR TITLE
feat: add token stats to floop_active MCP output

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -370,6 +370,12 @@ func (s *Server) handleFloopActive(ctx context.Context, req *sdk.CallToolRequest
 		summaries[i] = summary
 	}
 
+	// Compute total canonical tokens across active behaviors.
+	totalTokens := 0
+	for _, b := range result.Active {
+		totalTokens += (len(b.Content.Canonical) + 3) / 4
+	}
+
 	// Build context map for output
 	ctxMap := map[string]interface{}{
 		"file":     actCtx.FilePath,
@@ -408,6 +414,11 @@ func (s *Server) handleFloopActive(ctx context.Context, req *sdk.CallToolRequest
 		Context: ctxMap,
 		Active:  summaries,
 		Count:   len(summaries),
+		TokenStats: &TokenStats{
+			TotalCanonicalTokens: totalTokens,
+			BudgetDefault:        defaultTokenBudget,
+			BehaviorCount:        len(summaries),
+		},
 	}, nil
 }
 

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -11,11 +11,19 @@ type FloopActiveInput struct {
 	Task string `json:"task,omitempty" jsonschema:"Current task type (e.g. 'development', 'testing', 'refactoring')"`
 }
 
+// TokenStats provides token budget awareness for active behaviors.
+type TokenStats struct {
+	TotalCanonicalTokens int `json:"total_canonical_tokens"`
+	BudgetDefault        int `json:"budget_default"`
+	BehaviorCount        int `json:"behavior_count"`
+}
+
 // FloopActiveOutput defines the output for floop_active tool.
 type FloopActiveOutput struct {
-	Context map[string]interface{} `json:"context" jsonschema:"Context used for activation"`
-	Active  []BehaviorSummary      `json:"active" jsonschema:"List of active behaviors"`
-	Count   int                    `json:"count" jsonschema:"Number of active behaviors"`
+	Context    map[string]interface{} `json:"context" jsonschema:"Context used for activation"`
+	Active     []BehaviorSummary      `json:"active" jsonschema:"List of active behaviors"`
+	Count      int                    `json:"count" jsonschema:"Number of active behaviors"`
+	TokenStats *TokenStats            `json:"token_stats,omitempty"`
 }
 
 // BehaviorSummary provides a simplified view of a behavior.


### PR DESCRIPTION
## Summary
- Add `TokenStats` struct with `total_canonical_tokens`, `budget_default`, and `behavior_count` fields
- Populate `TokenStats` in `floop_active` output, computing token estimates from canonical content lengths (chars/4)
- Always returns `TokenStats` (non-nil pointer) so callers can assess token budget usage

## Test plan
- [x] Table-driven test `TestHandleFloopActive_TokenStats` with three cases:
  - Empty store: verifies zero tokens, budget=2000, count=0
  - Single behavior with known 16-char canonical: verifies (16+3)/4 = 4 tokens
  - Two behaviors: verifies token sum (4+3 = 7)
- [x] All existing MCP tests continue to pass
- [x] `go vet` clean, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)