### PR TITLE
chore: bump version to 0.2.0-dev

### DIFF
--- a/cmd/floop/main.go
+++ b/cmd/floop/main.go
@@ -53,7 +53,7 @@ func createLLMClient(cfg *config.FloopConfig) llm.Client {
 	}
 }
 
-var version = "0.1.0"
+var version = "0.2.0-dev"
 
 func main() {
 	rootCmd := &cobra.Command{


### PR DESCRIPTION
## Summary
- Bump version from `0.1.0` to `0.2.0-dev` after v0.1.0 tag/release

## Test plan
- [ ] `go build ./cmd/floop && ./floop version` shows `0.2.0-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)