### PR TITLE
fix: align CLI learn command with MCP auto-merge behavior

### DIFF
--- a/cmd/floop/cmd_activate.go
+++ b/cmd/floop/cmd_activate.go
@@ -278,6 +278,7 @@ func outputJSON(cmd *cobra.Command, results []session.FilteredResult, behaviorMa
 		"trigger":   triggerReason,
 		"behaviors": behaviors,
 		"count":     len(behaviors),
+		"scope":     "local",
 	}
 
 	enc := json.NewEncoder(cmd.OutOrStdout())

--- a/cmd/floop/cmd_query.go
+++ b/cmd/floop/cmd_query.go
@@ -195,6 +195,7 @@ This helps debug when a behavior isn't being applied as expected.`,
 					"behavior":    found,
 					"context":     ctx,
 					"explanation": explanation,
+					"scope":       "local",
 				})
 			} else {
 				fmt.Printf("Behavior: %s\n", found.Name)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,8 +44,9 @@ type GraphStore interface {
 	DeleteNode(ctx context.Context, id string) error
 
 	// QueryNodes queries nodes by predicate.
-	// Predicate is a map of field paths to required values.
-	// e.g., {"kind": "behavior", "metadata.confidence": 0.8}
+	// Predicate is a map of field names to required values.
+	// Supports flat key matching only (e.g., "kind", "id").
+	// e.g., {"kind": "behavior"}
 	QueryNodes(ctx context.Context, predicate map[string]interface{}) ([]Node, error)
 
 	// Edge operations


### PR DESCRIPTION
## Summary
- **cmd_learn.go**: Add `--auto-merge` flag (default `true`) to both `learn` and `reprocess` commands, matching the MCP handler's behavior (`handlers.go:488-502`)
- **cmd_query.go**: Add `"scope": "local"` to `why` subcommand JSON output
- **cmd_activate.go**: Add `"scope": "local"` to activate JSON output
- **store.go**: Fix `QueryNodes` doc comment — remove misleading nested path example, clarify only flat predicates supported

## Test plan
- [x] `go test ./cmd/floop/...` passes
- [x] `go test ./internal/store/...` passes
- [x] Full suite `go test ./...` passes
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)