### PR TITLE
fix: resolve CodeQL unsafe quoting alert in MergePrompt

### DIFF
--- a/internal/llm/prompts_test.go
+++ b/internal/llm/prompts_test.go
@@ -96,6 +96,33 @@ func TestMergePrompt(t *testing.T) {
 			t.Error("prompt should contain source_ids array")
 		}
 	})
+
+	t.Run("behavior content with double quotes does not corrupt prompt", func(t *testing.T) {
+		behaviors := []*models.Behavior{
+			{
+				ID:   "b1",
+				Name: `Use "pathlib" library`,
+				Kind: models.BehaviorKindDirective,
+				Content: models.BehaviorContent{
+					Canonical: `Always use "pathlib.Path" instead of "os.path"`,
+				},
+			},
+		}
+
+		prompt := MergePrompt(behaviors)
+
+		// Verify behavior content with quotes is preserved
+		if !strings.Contains(prompt, `Use "pathlib" library`) {
+			t.Error("prompt should contain behavior name with quotes")
+		}
+		if !strings.Contains(prompt, `Always use "pathlib.Path" instead of "os.path"`) {
+			t.Error("prompt should contain behavior content with quotes")
+		}
+		// Verify JSON template structure is intact
+		if !strings.Contains(prompt, `"source_ids": ["b1"]`) {
+			t.Error("prompt should contain properly formatted source_ids")
+		}
+	})
 }
 
 func TestExtractJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
- Refactors `MergePrompt` to use `strings.Builder` instead of a single `fmt.Sprintf` call, so user-provided behavior data is never interpolated through a format string containing JSON quote context
- Adds regression test verifying behavior content with double quotes preserves both the content and the JSON template structure
- Resolves CodeQL alert #1 (`go/unsafe-quoting`, CWE-94) on `internal/llm/prompts.go:98`

## Test plan
- [x] All existing `TestMergePrompt` subtests pass (empty, single, multiple behaviors)
- [x] New `"behavior content with double quotes does not corrupt prompt"` test passes
- [x] Full `internal/llm` test suite passes (46 tests)
- [x] Verify CodeQL re-scan no longer flags the alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)