### PR TITLE
docs: add comprehensive CLI reference for all 26 commands

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -988,7 +988,7 @@ floop mcp-server
 # }
 ```
 
-**See also:** [docs/integrations/mcp-server.md](integrations/mcp-server.md)
+**See also:** [MCP server integration guide](integrations/mcp-server.md), [Claude Code integration guide](integrations/claude-code.md)
 
 ---
 


### PR DESCRIPTION
## Summary
- Creates `docs/CLI_REFERENCE.md` — a 1024-line comprehensive reference for all 26 floop CLI commands
- Commands grouped by category: Core, Query, Curation, Management, Token Optimization, Graph, Backup, Hooks, Server
- Each command includes usage, description, flags table (with types/defaults), examples, and cross-references
- All flag details extracted directly from Go source files — nothing guessed

## Test plan
- [ ] Verify all 26 commands are documented (check against `floop --help`)
- [ ] Spot-check flag tables against source code for accuracy
- [ ] Verify examples use `floop` (not `./floop`)
- [ ] Run `make docs-validate` once Lane 3 is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)