### PR TITLE
feat: wire token budget enforcement into floop_active

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -457,6 +457,7 @@ func (s *Server) handleFloopActive(ctx context.Context, req *sdk.CallToolRequest
 			BehaviorCount:        plan.BehaviorCount(),
 			FullCount:            len(plan.FullBehaviors),
 			SummaryCount:         len(plan.SummarizedBehaviors),
+			NameOnlyCount:        len(plan.NameOnlyBehaviors),
 			OmittedCount:         len(plan.OmittedBehaviors),
 		},
 	}, nil

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -1067,12 +1067,7 @@ func TestHandleFloopActive_TokenBudgetEnforcement(t *testing.T) {
 	}
 
 	// Some behaviors should be demoted (summary, name-only, or omitted).
-	demoted := output.TokenStats.SummaryCount + output.TokenStats.OmittedCount
-	for _, b := range output.Active {
-		if b.Tier == "name-only" {
-			demoted++
-		}
-	}
+	demoted := output.TokenStats.SummaryCount + output.TokenStats.NameOnlyCount + output.TokenStats.OmittedCount
 	if demoted == 0 {
 		t.Error("No behaviors were demoted, want some below full tier")
 	}

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -18,6 +18,7 @@ type TokenStats struct {
 	BehaviorCount        int `json:"behavior_count"`
 	FullCount            int `json:"full_count"`
 	SummaryCount         int `json:"summary_count"`
+	NameOnlyCount        int `json:"name_only_count"`
 	OmittedCount         int `json:"omitted_count"`
 }
 


### PR DESCRIPTION
## Summary
- Wires `ActivationTierMapper.MapResults()` into `handleFloopActive` — the tiering code existed but was never called, causing all ~37 behaviors to be returned at full detail (~10.5k tokens)
- Behaviors are now tiered by activation score and demoted to fit the 2000-token budget: Full (>= 0.7), Summary (>= 0.3), Omitted (rest)
- Adds `Tier` field to `BehaviorSummary` and `FullCount`/`SummaryCount`/`OmittedCount` to `TokenStats`

## Changes
| File | What |
|------|------|
| `internal/mcp/schema.go` | Add `Tier` to `BehaviorSummary`, tier counts to `TokenStats` |
| `internal/mcp/handlers.go` | Wire `ActivationTierMapper.MapResults()` between conflict resolution and output building |
| `internal/mcp/handlers_test.go` | 2 new tests (budget enforcement, tier assignment), update existing token stats test |

## Test plan
- [x] `TestHandleFloopActive_TokenBudgetEnforcement` — 20 behaviors with large content exceed budget, verifies demotion occurs and tokens stay within budget
- [x] `TestHandleFloopActive_TierAssignment` — verifies Tier field is populated with valid values, high-activation behavior gets "full" tier
- [x] `TestHandleFloopActive_TokenStats` — updated expected values for tiered token costs
- [x] Full test suite passes (`go test ./...` — 24 packages, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)