### PR TITLE
feat: add dev tooling for graph screenshot pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ coverage.html
 .beads/*.db-wal
 .beads/daemon.*
 
+# Build artifacts
+build/
+
 # Git worktrees for parallel agent work
 .worktrees/
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-local test test-coverage lint lint-fix fmt fmt-check vet vuln ci clean docs-validate
+.PHONY: build build-local test test-coverage lint lint-fix fmt fmt-check vet vuln ci clean docs-validate graph-html graph-screenshot graph-preview
 
 build:
 	go build -o ./floop ./cmd/floop
@@ -37,6 +37,7 @@ ci: fmt-check lint vet test build
 
 clean:
 	rm -f ./floop coverage.out coverage.html
+	rm -rf build/
 
 docs-validate: build
 	@echo "Validating CLI reference documentation..."
@@ -51,3 +52,20 @@ docs-validate: build
 		exit 1; \
 	fi; \
 	echo "All commands documented."
+
+# Graph visualization dev targets
+graph-html:
+	@mkdir -p build/graph
+	GOWORK=off go build -o ./floop ./cmd/floop
+	./floop graph --format html -o build/graph/graph.html --no-open
+	@echo "HTML written to build/graph/graph.html"
+
+graph-screenshot: graph-html
+	@command -v node >/dev/null 2>&1 || (echo "node required (install Node.js)" && exit 1)
+	@test -d build/node_modules/puppeteer || npm install --prefix build puppeteer
+	NODE_PATH=build/node_modules node scripts/screenshot.js build/graph/graph.html build/graph/graph.png
+	@echo "Screenshot: build/graph/graph.png"
+
+graph-preview: graph-screenshot
+	@echo "Preview: build/graph/graph.html (open in browser)"
+	@echo "Screenshot: build/graph/graph.png"

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Usage: node scripts/screenshot.js <input.html> [output.png] [--width 1920] [--height 1080] [--wait 2000]
+// Requires: npx puppeteer (auto-downloads Chromium on first run)
+
+const puppeteer = require("puppeteer");
+const path = require("path");
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const opts = { width: 1920, height: 1080, wait: 2000 };
+  const positional = [];
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--width" && args[i + 1]) {
+      opts.width = parseInt(args[++i], 10);
+    } else if (args[i] === "--height" && args[i + 1]) {
+      opts.height = parseInt(args[++i], 10);
+    } else if (args[i] === "--wait" && args[i + 1]) {
+      opts.wait = parseInt(args[++i], 10);
+    } else if (!args[i].startsWith("--")) {
+      positional.push(args[i]);
+    }
+  }
+
+  if (positional.length === 0) {
+    console.error(
+      "Usage: node scripts/screenshot.js <input.html> [output.png] [--width 1920] [--height 1080] [--wait 2000]"
+    );
+    process.exit(1);
+  }
+
+  opts.input = path.resolve(positional[0]);
+  opts.output = positional[1]
+    ? path.resolve(positional[1])
+    : opts.input.replace(/\.html$/, ".png");
+
+  return opts;
+}
+
+async function screenshot(opts) {
+  const browser = await puppeteer.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: opts.width, height: opts.height });
+    await page.goto(`file://${opts.input}`, { waitUntil: "networkidle0" });
+
+    // Wait for force-graph physics to settle
+    await new Promise((r) => setTimeout(r, opts.wait));
+
+    await page.screenshot({ path: opts.output, fullPage: false });
+    console.log(`Screenshot saved: ${opts.output}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+const opts = parseArgs(process.argv);
+screenshot(opts).catch((err) => {
+  console.error("Screenshot failed:", err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `scripts/screenshot.js` — standalone Puppeteer script for capturing HTML graph screenshots as PNG
- Add Makefile targets: `graph-html`, `graph-screenshot`, `graph-preview` for single-command visual iteration
- Puppeteer auto-installs into `build/node_modules` on first run (no `package.json` needed)
- Uses `GOWORK=off` to support building from git worktrees
- All output goes to `build/` (gitignored)

## Test plan

- [x] `make graph-html` generates `build/graph/graph.html`
- [x] `make graph-screenshot` generates `build/graph/graph.png`
- [x] `make graph-preview` runs full pipeline
- [x] `make clean` removes `build/` directory
- [x] `build/` does not appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)