### PR TITLE
feat: re-add local LLM foundations with yzma-ready config

### DIFF
--- a/cmd/floop/main.go
+++ b/cmd/floop/main.go
@@ -11,7 +11,7 @@ import (
 
 // createLLMClient creates an LLM client based on config settings.
 // Returns nil if LLM is not enabled or configured.
-// Supports providers: anthropic, openai, ollama, subagent.
+// Supports providers: anthropic, openai, ollama, subagent, local.
 // When provider is "subagent" or not specified with LLM enabled, attempts auto-detection.
 func createLLMClient(cfg *config.FloopConfig) llm.Client {
 	if cfg == nil {
@@ -43,6 +43,14 @@ func createLLMClient(cfg *config.FloopConfig) llm.Client {
 		return llm.NewOpenAIClient(clientCfg)
 	case "anthropic":
 		return llm.NewAnthropicClient(clientCfg)
+	case "local":
+		return llm.NewLocalClient(llm.LocalConfig{
+			LibPath:            cfg.LLM.LocalLibPath,
+			ModelPath:          cfg.LLM.LocalModelPath,
+			EmbeddingModelPath: cfg.LLM.LocalEmbeddingModelPath,
+			GPULayers:          cfg.LLM.LocalGPULayers,
+			ContextSize:        cfg.LLM.LocalContextSize,
+		})
 	case "subagent":
 		if client := llm.DetectAndCreate(); client != nil {
 			return client

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -188,7 +188,7 @@ func TestValidate_InvalidProvider(t *testing.T) {
 }
 
 func TestValidate_ValidProviders(t *testing.T) {
-	validProviders := []string{"", "anthropic", "openai", "subagent"}
+	validProviders := []string{"", "anthropic", "openai", "subagent", "local"}
 
 	for _, provider := range validProviders {
 		t.Run(provider, func(t *testing.T) {
@@ -250,6 +250,76 @@ func TestLLMConfigString(t *testing.T) {
 	}
 	if !strings.Contains(s, "claude-3-haiku") {
 		t.Errorf("String() should contain model, got: %s", s)
+	}
+}
+
+func TestLoadFromFile_LocalConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+llm:
+  provider: local
+  enabled: true
+  local_lib_path: /usr/local/lib/yzma
+  local_model_path: /path/to/model.gguf
+  local_embedding_model_path: /path/to/embed.gguf
+  local_gpu_layers: 32
+  local_context_size: 2048
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	config, err := LoadFromFile(configPath)
+	if err != nil {
+		t.Fatalf("LoadFromFile failed: %v", err)
+	}
+
+	if config.LLM.Provider != "local" {
+		t.Errorf("expected Provider 'local', got '%s'", config.LLM.Provider)
+	}
+	if config.LLM.LocalLibPath != "/usr/local/lib/yzma" {
+		t.Errorf("expected LocalLibPath '/usr/local/lib/yzma', got '%s'", config.LLM.LocalLibPath)
+	}
+	if config.LLM.LocalModelPath != "/path/to/model.gguf" {
+		t.Errorf("expected LocalModelPath '/path/to/model.gguf', got '%s'", config.LLM.LocalModelPath)
+	}
+	if config.LLM.LocalEmbeddingModelPath != "/path/to/embed.gguf" {
+		t.Errorf("expected LocalEmbeddingModelPath '/path/to/embed.gguf', got '%s'", config.LLM.LocalEmbeddingModelPath)
+	}
+	if config.LLM.LocalGPULayers != 32 {
+		t.Errorf("expected LocalGPULayers 32, got %d", config.LLM.LocalGPULayers)
+	}
+	if config.LLM.LocalContextSize != 2048 {
+		t.Errorf("expected LocalContextSize 2048, got %d", config.LLM.LocalContextSize)
+	}
+}
+
+func TestEnvOverrides_LocalConfig(t *testing.T) {
+	t.Setenv("FLOOP_LOCAL_LIB_PATH", "/env/lib/yzma")
+	t.Setenv("FLOOP_LOCAL_MODEL_PATH", "/env/model.gguf")
+	t.Setenv("FLOOP_LOCAL_EMBEDDING_MODEL_PATH", "/env/embed.gguf")
+	t.Setenv("FLOOP_LOCAL_GPU_LAYERS", "16")
+	t.Setenv("FLOOP_LOCAL_CONTEXT_SIZE", "4096")
+
+	config := Default()
+	applyEnvOverrides(config)
+
+	if config.LLM.LocalLibPath != "/env/lib/yzma" {
+		t.Errorf("expected LocalLibPath '/env/lib/yzma', got '%s'", config.LLM.LocalLibPath)
+	}
+	if config.LLM.LocalModelPath != "/env/model.gguf" {
+		t.Errorf("expected LocalModelPath '/env/model.gguf', got '%s'", config.LLM.LocalModelPath)
+	}
+	if config.LLM.LocalEmbeddingModelPath != "/env/embed.gguf" {
+		t.Errorf("expected LocalEmbeddingModelPath '/env/embed.gguf', got '%s'", config.LLM.LocalEmbeddingModelPath)
+	}
+	if config.LLM.LocalGPULayers != 16 {
+		t.Errorf("expected LocalGPULayers 16, got %d", config.LLM.LocalGPULayers)
+	}
+	if config.LLM.LocalContextSize != 4096 {
+		t.Errorf("expected LocalContextSize 4096, got %d", config.LLM.LocalContextSize)
 	}
 }
 

--- a/internal/dedup/dedup.go
+++ b/internal/dedup/dedup.go
@@ -19,7 +19,7 @@ type DuplicateMatch struct {
 	Similarity float64 `json:"similarity" yaml:"similarity"`
 
 	// SimilarityMethod describes how similarity was computed.
-	// Valid values: "jaccard", "llm", "hybrid"
+	// Valid values: "jaccard", "llm", "embedding", "hybrid"
 	SimilarityMethod string `json:"similarity_method" yaml:"similarity_method"`
 
 	// MergeRecommended indicates whether merging is recommended based on

--- a/internal/dedup/store_dedup.go
+++ b/internal/dedup/store_dedup.go
@@ -211,14 +211,41 @@ type similarityResult struct {
 }
 
 // computeSimilarity calculates similarity between two behaviors.
-// Uses LLM-based comparison if available and configured, otherwise falls back
-// to Jaccard word overlap.
+// Uses embedding-based comparison if the LLM client supports EmbeddingComparer,
+// then tries LLM-based comparison, otherwise falls back to Jaccard word overlap.
 func (d *StoreDeduplicator) computeSimilarity(a, b *models.Behavior) similarityResult {
 	if d.config.UseLLM && d.llmClient != nil && d.llmClient.Available() {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		// Try LLM comparison
+		// Prefer embedding-based comparison if supported
+		if ec, ok := d.llmClient.(llm.EmbeddingComparer); ok {
+			sim, err := ec.CompareEmbeddings(ctx, a.Content.Canonical, b.Content.Canonical)
+			if err == nil {
+				method := "embedding"
+				isDup := sim >= d.config.SimilarityThreshold
+
+				if d.logger != nil {
+					d.logger.Debug("similarity computed", "behavior_a", a.ID, "behavior_b", b.ID, "score", sim, "method", method)
+				}
+				if d.decisions != nil {
+					d.decisions.Log(map[string]any{
+						"event":        "similarity_computed",
+						"behavior_a":   a.ID,
+						"behavior_b":   b.ID,
+						"score":        sim,
+						"method":       method,
+						"threshold":    d.config.SimilarityThreshold,
+						"is_duplicate": isDup,
+					})
+				}
+
+				return similarityResult{score: sim, method: method}
+			}
+			// Fall through on error
+		}
+
+		// Try full LLM comparison
 		result, err := d.llmClient.CompareBehaviors(ctx, a, b)
 		if err == nil && result != nil {
 			method := "llm"

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -87,3 +87,21 @@ type Client interface {
 	// For subagent clients, this checks that the CLI tool is available.
 	Available() bool
 }
+
+// EmbeddingComparer is an optional interface that Client implementations may support
+// for embedding-based similarity comparison. Consumers should type-assert to check
+// for support: if ec, ok := client.(EmbeddingComparer); ok { ... }
+type EmbeddingComparer interface {
+	// Embed returns a dense vector embedding for the given text.
+	Embed(ctx context.Context, text string) ([]float32, error)
+
+	// CompareEmbeddings embeds both texts and returns their cosine similarity.
+	// Returns a value between -1.0 and 1.0 (typically 0.0 to 1.0 for normalized embeddings).
+	CompareEmbeddings(ctx context.Context, a, b string) (float64, error)
+}
+
+// Closer is an optional interface for clients that hold resources requiring cleanup.
+// Consumers should type-assert and call Close when done: if c, ok := client.(Closer); ok { c.Close() }
+type Closer interface {
+	Close() error
+}

--- a/internal/llm/local.go
+++ b/internal/llm/local.go
@@ -1,0 +1,91 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+)
+
+// LocalClient implements Client and EmbeddingComparer using a local GGUF model.
+// The actual model backend (yzma) is wired in a separate PR; this file provides
+// the struct, config, constructor, and stub methods so the rest of the codebase
+// compiles and tests pass.
+type LocalClient struct {
+	libPath            string
+	embeddingModelPath string
+	gpuLayers          int
+	contextSize        int
+
+	// fallback handles MergeBehaviors until local generation is implemented.
+	fallback *FallbackClient
+}
+
+// LocalConfig configures the local LLM client.
+type LocalConfig struct {
+	// LibPath is the directory containing yzma shared libraries (.so/.dylib).
+	// Falls back to YZMA_LIB env var at runtime.
+	LibPath string
+
+	// ModelPath is the path to the GGUF model file for text generation.
+	ModelPath string
+
+	// EmbeddingModelPath is the path to the GGUF model file for embeddings.
+	// If empty, ModelPath is used for embeddings as well.
+	EmbeddingModelPath string
+
+	// GPULayers is the number of layers to offload to GPU (0 = CPU only).
+	GPULayers int
+
+	// ContextSize is the context window size in tokens.
+	ContextSize int
+}
+
+// NewLocalClient creates a new LocalClient. The model is not loaded until first use.
+func NewLocalClient(cfg LocalConfig) *LocalClient {
+	embPath := cfg.EmbeddingModelPath
+	if embPath == "" {
+		embPath = cfg.ModelPath
+	}
+	ctxSize := cfg.ContextSize
+	if ctxSize <= 0 {
+		ctxSize = 512
+	}
+	return &LocalClient{
+		libPath:            cfg.LibPath,
+		embeddingModelPath: embPath,
+		gpuLayers:          cfg.GPULayers,
+		contextSize:        ctxSize,
+		fallback:           NewFallbackClient(),
+	}
+}
+
+// Available returns true if both the library directory and model file exist on disk.
+func (c *LocalClient) Available() bool {
+	return false // Stub — yzma backend not yet wired
+}
+
+// Embed returns a dense vector embedding for the given text.
+func (c *LocalClient) Embed(_ context.Context, _ string) ([]float32, error) {
+	return nil, fmt.Errorf("local LLM not available: yzma backend not yet wired")
+}
+
+// CompareEmbeddings embeds both texts and returns their cosine similarity.
+func (c *LocalClient) CompareEmbeddings(_ context.Context, _, _ string) (float64, error) {
+	return 0, fmt.Errorf("local LLM not available: yzma backend not yet wired")
+}
+
+// CompareBehaviors compares two behaviors using embedding-based cosine similarity.
+func (c *LocalClient) CompareBehaviors(_ context.Context, _, _ *models.Behavior) (*ComparisonResult, error) {
+	return nil, fmt.Errorf("local LLM not available: yzma backend not yet wired")
+}
+
+// MergeBehaviors delegates to the rule-based FallbackClient.
+func (c *LocalClient) MergeBehaviors(ctx context.Context, behaviors []*models.Behavior) (*MergeResult, error) {
+	return c.fallback.MergeBehaviors(ctx, behaviors)
+}
+
+// Close is a no-op until the yzma backend is wired.
+func (c *LocalClient) Close() error {
+	return nil
+}

--- a/internal/llm/local_test.go
+++ b/internal/llm/local_test.go
@@ -1,0 +1,130 @@
+package llm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+)
+
+func TestNewLocalClient(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	if client == nil {
+		t.Fatal("NewLocalClient() returned nil")
+	}
+}
+
+func TestLocalClient_Available(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	if client.Available() {
+		t.Error("stub LocalClient.Available() should return false")
+	}
+}
+
+func TestLocalClient_CompareBehaviors(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	ctx := context.Background()
+
+	a := &models.Behavior{ID: "a", Content: models.BehaviorContent{Canonical: "test"}}
+	b := &models.Behavior{ID: "b", Content: models.BehaviorContent{Canonical: "test"}}
+
+	_, err := client.CompareBehaviors(ctx, a, b)
+	if err == nil {
+		t.Error("stub CompareBehaviors should return error")
+	}
+}
+
+func TestLocalClient_MergeBehaviors(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	ctx := context.Background()
+
+	behaviors := []*models.Behavior{
+		{ID: "a", Content: models.BehaviorContent{Canonical: "test a"}},
+		{ID: "b", Content: models.BehaviorContent{Canonical: "test b"}},
+	}
+
+	result, err := client.MergeBehaviors(ctx, behaviors)
+	if err != nil {
+		t.Errorf("MergeBehaviors should delegate to fallback, got error: %v", err)
+	}
+	if result == nil {
+		t.Error("MergeBehaviors should return a result from fallback")
+	}
+}
+
+func TestLocalClient_Embed(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	ctx := context.Background()
+
+	_, err := client.Embed(ctx, "test text")
+	if err == nil {
+		t.Error("stub Embed should return error")
+	}
+}
+
+func TestLocalClient_CompareEmbeddings(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	ctx := context.Background()
+
+	_, err := client.CompareEmbeddings(ctx, "text a", "text b")
+	if err == nil {
+		t.Error("stub CompareEmbeddings should return error")
+	}
+}
+
+func TestLocalClient_Close(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	if err := client.Close(); err != nil {
+		t.Errorf("stub Close() should not return error, got: %v", err)
+	}
+}
+
+func TestLocalClient_ImplementsInterfaces(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+
+	// Verify Client interface
+	var _ Client = client
+
+	// Verify EmbeddingComparer interface
+	var _ EmbeddingComparer = client
+
+	// Verify Closer interface
+	var _ Closer = client
+}
+
+func TestLocalConfig_Fields(t *testing.T) {
+	cfg := LocalConfig{
+		LibPath:            "/usr/local/lib/yzma",
+		ModelPath:          "/path/to/model.gguf",
+		EmbeddingModelPath: "/path/to/embed.gguf",
+		GPULayers:          32,
+		ContextSize:        2048,
+	}
+
+	client := NewLocalClient(cfg)
+	if client.embeddingModelPath != cfg.EmbeddingModelPath {
+		t.Errorf("embeddingModelPath = %q, want %q", client.embeddingModelPath, cfg.EmbeddingModelPath)
+	}
+	if client.libPath != cfg.LibPath {
+		t.Errorf("libPath = %q, want %q", client.libPath, cfg.LibPath)
+	}
+}
+
+func TestLocalConfig_FallbackModelPath(t *testing.T) {
+	cfg := LocalConfig{
+		ModelPath: "/path/to/model.gguf",
+		// EmbeddingModelPath is empty — should fall back to ModelPath
+	}
+
+	client := NewLocalClient(cfg)
+	if client.embeddingModelPath != cfg.ModelPath {
+		t.Errorf("embeddingModelPath = %q, want %q (fallback to ModelPath)", client.embeddingModelPath, cfg.ModelPath)
+	}
+}
+
+func TestLocalConfig_DefaultContextSize(t *testing.T) {
+	client := NewLocalClient(LocalConfig{})
+	if client.contextSize != 512 {
+		t.Errorf("contextSize = %d, want 512 (default)", client.contextSize)
+	}
+}

--- a/internal/llm/similarity.go
+++ b/internal/llm/similarity.go
@@ -1,0 +1,43 @@
+package llm
+
+import "math"
+
+// CosineSimilarity computes the cosine similarity between two float32 vectors.
+// Returns a value between -1.0 and 1.0. Returns 0.0 if either vector has zero magnitude
+// or the vectors have different lengths.
+func CosineSimilarity(a, b []float32) float64 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0.0
+	}
+
+	var dot, magA, magB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		magA += float64(a[i]) * float64(a[i])
+		magB += float64(b[i]) * float64(b[i])
+	}
+
+	magA = math.Sqrt(magA)
+	magB = math.Sqrt(magB)
+
+	if magA == 0 || magB == 0 {
+		return 0.0
+	}
+
+	return dot / (magA * magB)
+}
+
+// normalize performs in-place L2 normalization of a float32 vector.
+func normalize(vec []float32) {
+	var sum float64
+	for _, v := range vec {
+		sum += float64(v) * float64(v)
+	}
+	if sum == 0 {
+		return
+	}
+	norm := float32(math.Sqrt(sum))
+	for i := range vec {
+		vec[i] /= norm
+	}
+}

--- a/internal/llm/similarity_test.go
+++ b/internal/llm/similarity_test.go
@@ -1,0 +1,151 @@
+package llm
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCosineSimilarity(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []float32
+		b    []float32
+		want float64
+	}{
+		{
+			name: "identical vectors",
+			a:    []float32{1, 2, 3},
+			b:    []float32{1, 2, 3},
+			want: 1.0,
+		},
+		{
+			name: "orthogonal vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{0, 1, 0},
+			want: 0.0,
+		},
+		{
+			name: "anti-parallel vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{-1, 0, 0},
+			want: -1.0,
+		},
+		{
+			name: "scaled identical",
+			a:    []float32{1, 2, 3},
+			b:    []float32{2, 4, 6},
+			want: 1.0,
+		},
+		{
+			name: "partial similarity",
+			a:    []float32{1, 1, 0},
+			b:    []float32{1, 0, 0},
+			want: 1.0 / math.Sqrt(2),
+		},
+		{
+			name: "zero vector a",
+			a:    []float32{0, 0, 0},
+			b:    []float32{1, 2, 3},
+			want: 0.0,
+		},
+		{
+			name: "zero vector b",
+			a:    []float32{1, 2, 3},
+			b:    []float32{0, 0, 0},
+			want: 0.0,
+		},
+		{
+			name: "both zero vectors",
+			a:    []float32{0, 0, 0},
+			b:    []float32{0, 0, 0},
+			want: 0.0,
+		},
+		{
+			name: "different lengths",
+			a:    []float32{1, 2},
+			b:    []float32{1, 2, 3},
+			want: 0.0,
+		},
+		{
+			name: "empty vectors",
+			a:    []float32{},
+			b:    []float32{},
+			want: 0.0,
+		},
+		{
+			name: "nil vectors",
+			a:    nil,
+			b:    nil,
+			want: 0.0,
+		},
+		{
+			name: "single dimension identical",
+			a:    []float32{5},
+			b:    []float32{5},
+			want: 1.0,
+		},
+		{
+			name: "single dimension opposite",
+			a:    []float32{5},
+			b:    []float32{-3},
+			want: -1.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CosineSimilarity(tt.a, tt.b)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("CosineSimilarity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name string
+		vec  []float32
+	}{
+		{
+			name: "unit vector",
+			vec:  []float32{1, 0, 0},
+		},
+		{
+			name: "non-unit vector",
+			vec:  []float32{3, 4, 0},
+		},
+		{
+			name: "all equal",
+			vec:  []float32{1, 1, 1, 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vec := make([]float32, len(tt.vec))
+			copy(vec, tt.vec)
+			normalize(vec)
+
+			// Check that the L2 norm is 1.0
+			var sum float64
+			for _, v := range vec {
+				sum += float64(v) * float64(v)
+			}
+			norm := math.Sqrt(sum)
+			if math.Abs(norm-1.0) > 1e-6 {
+				t.Errorf("normalize() L2 norm = %v, want 1.0", norm)
+			}
+		})
+	}
+
+	t.Run("zero vector unchanged", func(t *testing.T) {
+		vec := []float32{0, 0, 0}
+		normalize(vec)
+		for i, v := range vec {
+			if v != 0 {
+				t.Errorf("normalize(zero)[%d] = %v, want 0", i, v)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Re-introduces pure Go foundations for local LLM support, redesigned for yzma (purego) instead of llama-go (CGo)
- Adds new `LocalLibPath` config field + `FLOOP_LOCAL_LIB_PATH` env override for yzma shared library directory
- LocalClient is a stub (always unavailable) — yzma backend wired in PR3

## Changes
- `client.go`: EmbeddingComparer and Closer optional interfaces
- `similarity.go`: CosineSimilarity + normalize functions with tests
- `local.go`: LocalClient stub with LocalConfig (includes LibPath)
- `local_test.go`: Unit tests for stub behavior, interface compliance, config fields
- `config.go`: LocalLibPath, LocalModelPath, LocalEmbeddingModelPath, LocalGPULayers, LocalContextSize + env overrides
- `config_test.go`: Tests for new config fields
- `main.go`: `case "local":` factory passes LibPath
- `store_dedup.go`: Embedding comparison path restored
- `dedup.go`: "embedding" in SimilarityMethod docs

**Stacked on:** #57 (revert)

## Test plan
- [x] `go build ./cmd/floop` — builds cleanly
- [x] `go vet ./...` — no issues
- [x] `go test ./...` — all 25 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)