### PR TITLE
feat: add internal/tagging package

### DIFF
--- a/internal/tagging/dictionary.go
+++ b/internal/tagging/dictionary.go
@@ -1,0 +1,106 @@
+package tagging
+
+import (
+	"sort"
+	"strings"
+)
+
+// Dictionary maps keywords (tokens found in behavior text) to normalized tags.
+// Multiple keywords can map to the same tag (e.g., "golang" and "go" both map to "go").
+type Dictionary struct {
+	entries map[string]string // lowercase keyword → normalized tag
+}
+
+// NewDictionary creates a Dictionary with the default keyword→tag mappings.
+func NewDictionary() *Dictionary {
+	d := &Dictionary{
+		entries: make(map[string]string, 200),
+	}
+	d.loadDefaults()
+	return d
+}
+
+// Lookup returns the normalized tag for a token, if any.
+// Matching is case-insensitive.
+func (d *Dictionary) Lookup(token string) (string, bool) {
+	tag, ok := d.entries[strings.ToLower(token)]
+	return tag, ok
+}
+
+// AllTags returns a sorted, deduplicated list of all tag values in the dictionary.
+func (d *Dictionary) AllTags() []string {
+	seen := make(map[string]bool, len(d.entries))
+	for _, tag := range d.entries {
+		seen[tag] = true
+	}
+	tags := make([]string, 0, len(seen))
+	for tag := range seen {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// add registers one or more keywords that map to the same tag.
+func (d *Dictionary) add(tag string, keywords ...string) {
+	for _, kw := range keywords {
+		d.entries[strings.ToLower(kw)] = tag
+	}
+}
+
+// loadDefaults populates the dictionary with the standard keyword→tag mappings.
+func (d *Dictionary) loadDefaults() {
+	// Languages
+	d.add("go", "go", "golang", "go-lang")
+	d.add("python", "python", "py", "pip")
+	d.add("rust", "rust", "cargo", "rustc")
+	d.add("javascript", "javascript", "js", "node", "nodejs")
+	d.add("typescript", "typescript", "ts", "tsx")
+	d.add("ruby", "ruby", "rb", "gem", "bundler")
+	d.add("java", "java", "jvm", "maven", "gradle")
+	d.add("sql", "sql", "sqlite", "postgres", "postgresql", "mysql")
+	d.add("yaml", "yaml", "yml")
+	d.add("json", "json", "jsonl")
+	d.add("bash", "bash", "sh", "shell", "zsh")
+
+	// Tools
+	d.add("git", "git", "git-town", "gitignore")
+	d.add("docker", "docker", "dockerfile", "container", "containers")
+	d.add("make", "make", "makefile")
+	d.add("npm", "npm", "yarn", "pnpm")
+	d.add("cli", "cobra", "cli", "command-line")
+	d.add("linting", "golangci-lint", "golangci", "lint", "linter", "linting", "eslint")
+
+	// Testing concepts
+	d.add("testing", "test", "tests", "testing", "unittest", "unit-test")
+	d.add("tdd", "tdd", "red-green-refactor")
+
+	// Development concepts
+	d.add("security", "security", "vulnerability", "owasp", "injection", "xss", "sanitize", "sanitization")
+	d.add("error-handling", "error-handling", "error-wrap", "error-wrapping", "errors")
+	d.add("concurrency", "concurrency", "goroutine", "goroutines", "mutex", "channel", "channels")
+	d.add("logging", "logging", "log", "logs", "logger")
+	d.add("configuration", "configuration", "config", "settings", "env", "environment")
+	d.add("debugging", "debugging", "debug", "debugger", "breakpoint")
+	d.add("refactoring", "refactoring", "refactor", "restructure")
+
+	// Workflow
+	d.add("ci", "ci", "ci/cd", "pipeline", "github-actions", "workflow-file")
+	d.add("pr", "pr", "pull-request", "pull-requests", "code-review")
+	d.add("workflow", "workflow", "process", "procedure")
+	d.add("worktree", "worktree", "worktrees")
+
+	// Architecture
+	d.add("api", "api", "rest", "endpoint", "endpoints", "http")
+	d.add("mcp", "mcp", "mcp-server", "model-context-protocol")
+	d.add("database", "database", "db", "schema", "migration", "migrations")
+	d.add("filesystem", "filesystem", "file", "files", "directory", "path", "paths")
+	d.add("serialization", "serialization", "marshal", "unmarshal", "encode", "decode")
+
+	// Project-specific
+	d.add("beads", "beads", "bead", "issue-tracking")
+	d.add("floop", "floop", "floop_learn", "floop_active", "floop_list", "feedback-loop")
+	d.add("behavior", "behavior", "behaviors", "behaviour")
+	d.add("correction", "correction", "corrections")
+	d.add("spreading-activation", "spreading", "activation", "spreading-activation")
+}

--- a/internal/tagging/dictionary_test.go
+++ b/internal/tagging/dictionary_test.go
@@ -1,0 +1,77 @@
+package tagging
+
+import (
+	"testing"
+)
+
+func TestNewDictionary(t *testing.T) {
+	dict := NewDictionary()
+
+	if dict == nil {
+		t.Fatal("NewDictionary() returned nil")
+	}
+
+	// Should have entries.
+	if len(dict.entries) == 0 {
+		t.Error("dictionary has no entries")
+	}
+}
+
+func TestDictionary_Lookup(t *testing.T) {
+	dict := NewDictionary()
+
+	tests := []struct {
+		name    string
+		token   string
+		wantTag string
+		wantOK  bool
+	}{
+		{"exact match", "git", "git", true},
+		{"case insensitive", "Git", "git", true},
+		{"compound keyword", "golangci-lint", "linting", true},
+		{"unknown token", "xyzzy", "", false},
+		{"language name", "python", "python", true},
+		{"tool maps to concept", "cobra", "cli", true},
+		{"tdd keyword", "tdd", "tdd", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTag, gotOK := dict.Lookup(tt.token)
+			if gotOK != tt.wantOK {
+				t.Errorf("Lookup(%q) ok = %v, want %v", tt.token, gotOK, tt.wantOK)
+			}
+			if gotTag != tt.wantTag {
+				t.Errorf("Lookup(%q) = %q, want %q", tt.token, gotTag, tt.wantTag)
+			}
+		})
+	}
+}
+
+func TestDictionary_AllTags(t *testing.T) {
+	dict := NewDictionary()
+	tags := dict.AllTags()
+
+	if len(tags) == 0 {
+		t.Error("AllTags() returned empty")
+	}
+
+	// Should be sorted.
+	for i := 1; i < len(tags); i++ {
+		if tags[i] < tags[i-1] {
+			t.Errorf("AllTags() not sorted: %v", tags)
+			break
+		}
+	}
+
+	// Should contain common tags.
+	tagSet := make(map[string]bool, len(tags))
+	for _, tag := range tags {
+		tagSet[tag] = true
+	}
+	for _, want := range []string{"git", "go", "testing", "linting"} {
+		if !tagSet[want] {
+			t.Errorf("AllTags() missing expected tag %q", want)
+		}
+	}
+}

--- a/internal/tagging/extract.go
+++ b/internal/tagging/extract.go
@@ -1,0 +1,56 @@
+package tagging
+
+import (
+	"regexp"
+	"sort"
+
+	"github.com/nvandessel/feedback-loop/internal/sanitize"
+)
+
+// MaxTags is the maximum number of tags extracted per behavior.
+const MaxTags = 8
+
+// tokenPattern splits text into tokens. Matches words and hyphenated compounds
+// like "golangci-lint", "error-handling", "red-green-refactor".
+var tokenPattern = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9]*(?:[-_][a-zA-Z0-9]+)*`)
+
+// ExtractTags extracts normalized tags from behavior text using the dictionary.
+// Returns a sorted, deduplicated, sanitized slice capped at MaxTags.
+// Returns nil if no tags are found.
+func ExtractTags(text string, dict *Dictionary) []string {
+	if text == "" || dict == nil {
+		return nil
+	}
+
+	tokens := tokenPattern.FindAllString(text, -1)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]bool, MaxTags)
+	var tags []string
+
+	for _, token := range tokens {
+		tag, ok := dict.Lookup(token)
+		if !ok {
+			continue
+		}
+		if seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		tags = append(tags, sanitize.SanitizeBehaviorName(tag))
+	}
+
+	if len(tags) == 0 {
+		return nil
+	}
+
+	sort.Strings(tags)
+
+	if len(tags) > MaxTags {
+		tags = tags[:MaxTags]
+	}
+
+	return tags
+}

--- a/internal/tagging/extract_test.go
+++ b/internal/tagging/extract_test.go
@@ -1,0 +1,106 @@
+package tagging
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractTags(t *testing.T) {
+	dict := NewDictionary()
+
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "empty string",
+			text: "",
+			want: nil,
+		},
+		{
+			name: "single keyword",
+			text: "Always run golangci-lint before committing",
+			want: []string{"linting"},
+		},
+		{
+			name: "multiple keywords from different categories",
+			text: "Use git -C for worktree operations when testing Go code",
+			want: []string{"git", "go", "testing", "worktree"},
+		},
+		{
+			name: "deduplicated tags",
+			text: "When writing Go code, always use go fmt and go test",
+			want: []string{"go", "testing"},
+		},
+		{
+			name: "case insensitive matching",
+			text: "Docker containers should use YAML configuration",
+			want: []string{"configuration", "docker", "yaml"},
+		},
+		{
+			name: "no matching keywords",
+			text: "The quick brown fox jumps over the lazy dog",
+			want: nil,
+		},
+		{
+			name: "max tags enforced",
+			text: "Use git docker make npm golang testing linting security debugging refactoring ci pr yaml json bash",
+			want: []string{"bash", "ci", "debugging", "docker", "git", "go", "json", "linting"},
+		},
+		{
+			name: "project-specific keywords",
+			text: "Use floop_learn to capture corrections for beads workflow",
+			want: []string{"beads", "correction", "floop", "workflow"},
+		},
+		{
+			name: "compound keywords",
+			text: "Always follow the TDD red-green-refactor cycle",
+			want: []string{"tdd"},
+		},
+		{
+			name: "error handling phrase",
+			text: "Use error-wrapping with fmt.Errorf for error handling",
+			want: []string{"error-handling"},
+		},
+		{
+			name: "tool names recognized",
+			text: "Configure cobra commands with golangci-lint checks",
+			want: []string{"cli", "linting"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractTags(tt.text, dict)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractTags() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractTags_MaxTags(t *testing.T) {
+	dict := NewDictionary()
+
+	// A string with many keywords should be capped at MaxTags.
+	text := "git docker make npm golang testing linting security debugging refactoring ci pr yaml json bash python rust javascript"
+	got := ExtractTags(text, dict)
+	if len(got) > MaxTags {
+		t.Errorf("ExtractTags() returned %d tags, want at most %d", len(got), MaxTags)
+	}
+}
+
+func TestExtractTags_Sorted(t *testing.T) {
+	dict := NewDictionary()
+
+	text := "worktree git testing go"
+	got := ExtractTags(text, dict)
+
+	for i := 1; i < len(got); i++ {
+		if got[i] < got[i-1] {
+			t.Errorf("tags not sorted: %v", got)
+			break
+		}
+	}
+}

--- a/internal/tagging/jaccard.go
+++ b/internal/tagging/jaccard.go
@@ -1,0 +1,53 @@
+package tagging
+
+// JaccardSimilarity computes the Jaccard index between two string slices.
+// Returns 0.0 if both are empty.
+func JaccardSimilarity(a, b []string) float64 {
+	if len(a) == 0 && len(b) == 0 {
+		return 0.0
+	}
+
+	setA := make(map[string]bool, len(a))
+	for _, s := range a {
+		setA[s] = true
+	}
+
+	setB := make(map[string]bool, len(b))
+	for _, s := range b {
+		setB[s] = true
+	}
+
+	intersection := 0
+	for s := range setA {
+		if setB[s] {
+			intersection++
+		}
+	}
+
+	union := len(setA) + len(setB) - intersection
+	if union == 0 {
+		return 0.0
+	}
+
+	return float64(intersection) / float64(union)
+}
+
+// IntersectTags returns the intersection of two tag slices, preserving order of the first slice.
+func IntersectTags(a, b []string) []string {
+	if len(a) == 0 || len(b) == 0 {
+		return nil
+	}
+
+	setB := make(map[string]bool, len(b))
+	for _, s := range b {
+		setB[s] = true
+	}
+
+	var result []string
+	for _, s := range a {
+		if setB[s] {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/internal/tagging/jaccard_test.go
+++ b/internal/tagging/jaccard_test.go
@@ -1,0 +1,64 @@
+package tagging
+
+import (
+	"math"
+	"testing"
+)
+
+func TestJaccardSimilarity(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want float64
+	}{
+		{"both empty", nil, nil, 0.0},
+		{"a empty", nil, []string{"go"}, 0.0},
+		{"b empty", []string{"go"}, nil, 0.0},
+		{"identical", []string{"go", "testing"}, []string{"go", "testing"}, 1.0},
+		{"disjoint", []string{"go"}, []string{"python"}, 0.0},
+		{"partial overlap", []string{"go", "testing", "git"}, []string{"go", "testing", "linting"}, 0.5},
+		{"subset", []string{"go"}, []string{"go", "testing"}, 0.5},
+		{"single shared", []string{"go", "git"}, []string{"go", "python"}, 1.0 / 3.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := JaccardSimilarity(tt.a, tt.b)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("JaccardSimilarity(%v, %v) = %f, want %f", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntersectTags(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{"both empty", nil, nil, nil},
+		{"no overlap", []string{"go"}, []string{"python"}, nil},
+		{"full overlap", []string{"go", "testing"}, []string{"go", "testing"}, []string{"go", "testing"}},
+		{"partial overlap preserves a order", []string{"testing", "go", "git"}, []string{"go", "testing"}, []string{"testing", "go"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IntersectTags(tt.a, tt.b)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return // both nil/empty is fine
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("IntersectTags() len = %d, want %d: got %v", len(got), len(tt.want), got)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("IntersectTags()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/tagging/` package with dictionary-based tag extraction
- `Dictionary` maps ~100 keywords to normalized tags (languages, tools, testing, workflow, architecture, project-specific)
- `ExtractTags()` tokenizes text, looks up tags, deduplicates, sorts, caps at MaxTags=8
- `JaccardSimilarity()` and `IntersectTags()` for shared tag utilities

**Part 1/4 of feature-based associative memory stack** (epic: feedback-loop-0if)

## Stack
1. **This PR** - tagging package
2. feat/tag-extraction - wire into learning pipeline
3. feat/tag-affinity - virtual edges in spreading engine
4. feat/tag-backfill - bug fix + backfill CLI

## Test plan
- [x] `TestExtractTags` - 11 cases (empty, single, multiple, dedup, case-insensitive, max tags, etc.)
- [x] `TestDictionary_Lookup` - 7 cases (exact, case-insensitive, compound, unknown, language, tool, tdd)
- [x] `TestJaccardSimilarity` - 8 cases (empty, identical, disjoint, partial, subset)
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)