### PR TITLE
feat: wire tag extraction into learning pipeline

### DIFF
--- a/internal/learning/extract.go
+++ b/internal/learning/extract.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/models"
 	"github.com/nvandessel/feedback-loop/internal/sanitize"
+	"github.com/nvandessel/feedback-loop/internal/tagging"
 )
 
 // BehaviorExtractor transforms corrections into candidate behaviors.
@@ -32,6 +33,8 @@ type behaviorExtractor struct {
 	preferenceSignals []string
 	// procedureSignals are keywords that indicate a procedure behavior
 	procedureSignals []string
+	// tagDict maps keywords to normalized tags for semantic feature extraction
+	tagDict *tagging.Dictionary
 }
 
 // NewBehaviorExtractor creates a new BehaviorExtractor instance.
@@ -49,6 +52,7 @@ func NewBehaviorExtractor() BehaviorExtractor {
 			"first", "then", "after that", "finally",
 			"step 1", "step 2", "workflow", "process",
 		},
+		tagDict: tagging.NewDictionary(),
 	}
 }
 
@@ -220,6 +224,7 @@ func (e *behaviorExtractor) buildContent(correction models.Correction) models.Be
 
 	content := models.BehaviorContent{
 		Canonical:  sanitizedCorrected,
+		Tags:       tagging.ExtractTags(sanitizedCorrected, e.tagDict),
 		Structured: make(map[string]interface{}),
 	}
 

--- a/internal/learning/extract_test.go
+++ b/internal/learning/extract_test.go
@@ -577,6 +577,52 @@ func TestBehaviorExtractor_BuildContent(t *testing.T) {
 	}
 }
 
+func TestBehaviorExtractor_BuildContent_Tags(t *testing.T) {
+	extractor := NewBehaviorExtractor().(*behaviorExtractor)
+
+	tests := []struct {
+		name       string
+		correction models.Correction
+		wantTags   []string
+	}{
+		{
+			name: "git-related correction gets git tag",
+			correction: models.Correction{
+				CorrectedAction: "Always use git -C for worktree operations",
+			},
+			wantTags: []string{"git", "worktree"},
+		},
+		{
+			name: "testing correction gets testing tag",
+			correction: models.Correction{
+				CorrectedAction: "Follow TDD when writing Go tests",
+			},
+			wantTags: []string{"go", "tdd", "testing"},
+		},
+		{
+			name: "no keywords produces nil tags",
+			correction: models.Correction{
+				CorrectedAction: "be more careful next time",
+			},
+			wantTags: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := extractor.buildContent(tt.correction)
+			if len(content.Tags) != len(tt.wantTags) {
+				t.Fatalf("Tags = %v, want %v", content.Tags, tt.wantTags)
+			}
+			for i, tag := range content.Tags {
+				if tag != tt.wantTags[i] {
+					t.Errorf("Tags[%d] = %q, want %q", i, tag, tt.wantTags[i])
+				}
+			}
+		})
+	}
+}
+
 func TestBehaviorExtractor_Extract_Provenance(t *testing.T) {
 	extractor := NewBehaviorExtractor()
 


### PR DESCRIPTION
## Summary
- Behaviors extracted from corrections now automatically get semantic tags
- Added `tagDict` field to `behaviorExtractor`, initialized with default dictionary
- `tagging.ExtractTags()` called in `buildContent()` to populate `Content.Tags`

**Part 2/4 of feature-based associative memory stack** (epic: feedback-loop-0if)

## Test plan
- [x] `TestBehaviorExtractor_BuildContent_Tags` - 3 cases (git tags, testing tags, no keywords)
- [x] All existing learning tests still pass
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)