### PR TITLE
feat: fix NodeToBehavior tag round-trip and add backfill CLI

### DIFF
--- a/cmd/floop/cmd_tags.go
+++ b/cmd/floop/cmd_tags.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/nvandessel/feedback-loop/internal/constants"
+	"github.com/nvandessel/feedback-loop/internal/learning"
+	"github.com/nvandessel/feedback-loop/internal/store"
+	"github.com/nvandessel/feedback-loop/internal/tagging"
+	"github.com/spf13/cobra"
+)
+
+func newTagsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tags",
+		Short: "Manage behavior tags",
+		Long:  `Commands for managing semantic tags on behaviors.`,
+	}
+
+	cmd.AddCommand(newTagsBackfillCmd())
+	return cmd
+}
+
+func newTagsBackfillCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "Add tags to behaviors that have none",
+		Long: `Extracts semantic tags from behavior content and adds them to
+behaviors that currently have no tags. Uses the same dictionary-based
+extraction that new behaviors get automatically.
+
+Use --dry-run to preview changes without modifying the store.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			root, _ := cmd.Flags().GetString("root")
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			jsonOut, _ := cmd.Flags().GetBool("json")
+			scope, _ := cmd.Flags().GetString("scope")
+
+			storeScope := constants.Scope(scope)
+			if !storeScope.Valid() {
+				storeScope = constants.ScopeBoth
+			}
+
+			graphStore, err := store.NewMultiGraphStore(root, storeScope)
+			if err != nil {
+				return fmt.Errorf("opening graph store: %w", err)
+			}
+			defer graphStore.Close()
+
+			return runTagsBackfill(graphStore, dryRun, jsonOut)
+		},
+	}
+
+	cmd.Flags().Bool("dry-run", false, "Preview changes without modifying the store")
+	cmd.Flags().String("scope", "both", "Scope: local, global, or both")
+	return cmd
+}
+
+type backfillResult struct {
+	BehaviorID string   `json:"behavior_id"`
+	Name       string   `json:"name"`
+	Tags       []string `json:"tags"`
+}
+
+type backfillOutput struct {
+	Updated []backfillResult `json:"updated"`
+	Skipped int              `json:"skipped"`
+	Total   int              `json:"total"`
+	DryRun  bool             `json:"dry_run"`
+}
+
+func runTagsBackfill(graphStore store.GraphStore, dryRun, jsonOut bool) error {
+	ctx := context.Background()
+	dict := tagging.NewDictionary()
+
+	var output backfillOutput
+	output.DryRun = dryRun
+
+	nodes, err := graphStore.QueryNodes(ctx, map[string]interface{}{"kind": "behavior"})
+	if err != nil {
+		return fmt.Errorf("querying behaviors: %w", err)
+	}
+
+	for _, node := range nodes {
+		output.Total++
+		b := learning.NodeToBehavior(node)
+
+		if len(b.Content.Tags) > 0 {
+			output.Skipped++
+			continue
+		}
+
+		tags := tagging.ExtractTags(b.Content.Canonical, dict)
+		if len(tags) == 0 {
+			output.Skipped++
+			continue
+		}
+
+		if !dryRun {
+			contentMap, ok := node.Content["content"].(map[string]interface{})
+			if !ok {
+				contentMap = make(map[string]interface{})
+				node.Content["content"] = contentMap
+			}
+			contentMap["tags"] = tags
+
+			if _, err := graphStore.AddNode(ctx, node); err != nil {
+				return fmt.Errorf("updating node %s: %w", node.ID, err)
+			}
+		}
+
+		output.Updated = append(output.Updated, backfillResult{
+			BehaviorID: b.ID,
+			Name:       b.Name,
+			Tags:       tags,
+		})
+	}
+
+	if jsonOut {
+		return json.NewEncoder(os.Stdout).Encode(output)
+	}
+
+	if dryRun {
+		fmt.Println("DRY RUN — no changes made")
+		fmt.Println()
+	}
+	fmt.Printf("Total: %d behaviors, %d would be tagged, %d skipped\n",
+		output.Total, len(output.Updated), output.Skipped)
+
+	for _, r := range output.Updated {
+		fmt.Printf("  %s -> %v\n", r.Name, r.Tags)
+	}
+
+	return nil
+}

--- a/cmd/floop/main.go
+++ b/cmd/floop/main.go
@@ -116,6 +116,8 @@ context-aware behavior activation for consistent agent operation.`,
 		newRestoreFromBackupCmd(),
 		// Hook management commands
 		newUpgradeCmd(),
+		// Tag management commands
+		newTagsCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/learning/place.go
+++ b/internal/learning/place.go
@@ -471,6 +471,13 @@ func NodeToBehavior(node store.Node) models.Behavior {
 		if structured, ok := content["structured"].(map[string]interface{}); ok {
 			b.Content.Structured = structured
 		}
+		if tags, ok := content["tags"].([]interface{}); ok {
+			for _, t := range tags {
+				if s, ok := t.(string); ok {
+					b.Content.Tags = append(b.Content.Tags, s)
+				}
+			}
+		}
 	} else if content, ok := node.Content["content"].(models.BehaviorContent); ok {
 		b.Content = content
 	}

--- a/internal/learning/place_test.go
+++ b/internal/learning/place_test.go
@@ -551,6 +551,53 @@ func TestNodeToBehavior_StringCreatedAt(t *testing.T) {
 	}
 }
 
+func TestNodeToBehavior_Tags(t *testing.T) {
+	node := store.Node{
+		ID:   "tag-test",
+		Kind: "behavior",
+		Content: map[string]interface{}{
+			"kind": "directive",
+			"content": map[string]interface{}{
+				"canonical": "use git worktree",
+				"tags":      []interface{}{"git", "worktree"},
+			},
+		},
+		Metadata: map[string]interface{}{},
+	}
+
+	b := NodeToBehavior(node)
+
+	if len(b.Content.Tags) != 2 {
+		t.Fatalf("NodeToBehavior() Tags len = %d, want 2", len(b.Content.Tags))
+	}
+	if b.Content.Tags[0] != "git" {
+		t.Errorf("Tags[0] = %q, want %q", b.Content.Tags[0], "git")
+	}
+	if b.Content.Tags[1] != "worktree" {
+		t.Errorf("Tags[1] = %q, want %q", b.Content.Tags[1], "worktree")
+	}
+}
+
+func TestNodeToBehavior_NoTags(t *testing.T) {
+	node := store.Node{
+		ID:   "no-tag-test",
+		Kind: "behavior",
+		Content: map[string]interface{}{
+			"kind": "directive",
+			"content": map[string]interface{}{
+				"canonical": "do something",
+			},
+		},
+		Metadata: map[string]interface{}{},
+	}
+
+	b := NodeToBehavior(node)
+
+	if len(b.Content.Tags) != 0 {
+		t.Errorf("NodeToBehavior() Tags = %v, want empty", b.Content.Tags)
+	}
+}
+
 func TestGraphPlacer_determineEdges(t *testing.T) {
 	s := store.NewInMemoryGraphStore()
 	gp := NewGraphPlacer(s).(*graphPlacer)


### PR DESCRIPTION
## Summary
- **Bug fix:** `NodeToBehavior` now extracts tags from `content["tags"]` — previously tags were silently dropped during store round-trip
- **New CLI:** `floop tags backfill` retroactively tags existing behaviors using the same dictionary extraction
  - `--dry-run` to preview without changes
  - `--scope` for local/global/both
  - `--json` for agent consumption

**Part 4/4 of feature-based associative memory stack** (epic: feedback-loop-0if)

## Test plan
- [x] `TestNodeToBehavior_Tags` - tags survive round-trip
- [x] `TestNodeToBehavior_NoTags` - no tags doesn't break
- [x] `go build ./...` compiles with new CLI command
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)