### PR TITLE
refactor: centralize token estimation

### DIFF
--- a/internal/assembly/compile.go
+++ b/internal/assembly/compile.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/nvandessel/feedback-loop/internal/models"
+	"github.com/nvandessel/feedback-loop/internal/tokens"
 )
 
 // Format specifies the output format for compiled prompts
@@ -266,14 +267,10 @@ func (c *Compiler) assembleText(sections []PromptSection) string {
 	return strings.TrimSpace(strings.Join(parts, "\n"))
 }
 
-// estimateTokens provides a rough token count estimate
-// Uses the common heuristic of ~4 characters per token
+// estimateTokens provides a rough token count estimate.
+// Delegates to tokens.EstimateTokens for the canonical implementation.
 func estimateTokens(text string) int {
-	if text == "" {
-		return 0
-	}
-	// Rough estimate: 1 token ≈ 4 characters for English text
-	return (len(text) + 3) / 4
+	return tokens.EstimateTokens(text)
 }
 
 // TieredCompiledPrompt extends CompiledPrompt with tiering information

--- a/internal/tiering/activation_tiers.go
+++ b/internal/tiering/activation_tiers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nvandessel/feedback-loop/internal/models"
 	"github.com/nvandessel/feedback-loop/internal/spreading"
+	"github.com/nvandessel/feedback-loop/internal/tokens"
 )
 
 // ActivationTierConfig maps activation levels to tiers.
@@ -175,11 +176,7 @@ func (m *ActivationTierMapper) MapResults(
 // estimateTokensForTier estimates the token cost for a behavior at a given tier.
 func estimateTokensForTier(b *models.Behavior, tier models.InjectionTier) int {
 	content := contentForTier(b, tier)
-	if content == "" {
-		return 0
-	}
-	// Rough estimate: 1 token ~ 4 characters.
-	return (len(content) + 3) / 4
+	return tokens.EstimateTokens(content)
 }
 
 // contentForTier returns the content string for a behavior at a given tier.

--- a/internal/tiering/assigner.go
+++ b/internal/tiering/assigner.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nvandessel/feedback-loop/internal/models"
 	"github.com/nvandessel/feedback-loop/internal/ranking"
 	"github.com/nvandessel/feedback-loop/internal/summarization"
+	"github.com/nvandessel/feedback-loop/internal/tokens"
 )
 
 // TierAssignerConfig configures the tier assigner
@@ -192,11 +193,7 @@ func (a *TierAssigner) getSummary(behavior *models.Behavior) string {
 
 // estimateTokens estimates token count for text
 func (a *TierAssigner) estimateTokens(text string) int {
-	if text == "" {
-		return 0
-	}
-	// Rough estimate: 1 token ≈ 4 characters
-	return (len(text) + 3) / 4
+	return tokens.EstimateTokens(text)
 }
 
 // QuickAssign is a convenience method that creates a scorer and summarizer internally

--- a/internal/tokens/estimate.go
+++ b/internal/tokens/estimate.go
@@ -1,0 +1,11 @@
+// Package tokens provides token estimation utilities for the floop system.
+package tokens
+
+// EstimateTokens provides a rough token count estimate for text.
+// Uses the common heuristic of ~4 characters per token for English text.
+func EstimateTokens(text string) int {
+	if text == "" {
+		return 0
+	}
+	return (len(text) + 3) / 4
+}

--- a/internal/tokens/estimate_test.go
+++ b/internal/tokens/estimate_test.go
@@ -1,0 +1,27 @@
+package tokens
+
+import "testing"
+
+func TestEstimateTokens(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int
+	}{
+		{"empty string", "", 0},
+		{"single char", "a", 1},
+		{"four chars (1 token)", "abcd", 1},
+		{"five chars (2 tokens)", "abcde", 2},
+		{"eight chars (2 tokens)", "abcdefgh", 2},
+		{"typical short text", "hello world", 3},
+		{"longer text", "This is a longer piece of text that should estimate to more tokens", 17},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EstimateTokens(tt.input)
+			if got != tt.want {
+				t.Errorf("EstimateTokens(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Create `internal/tokens/estimate.go` with `EstimateTokens()` function
- Migrate 3 callers to use centralized function (activation_tiers.go, assigner.go, compile.go)
- optimize.go already calls through compile.go's wrapper
- Table-driven tests in estimate_test.go

**Stack:** 1/5 — this is the base of the token budget consolidation stack.

## Test plan
- [x] `go test ./internal/tokens/` — new package tests pass
- [x] `go test ./...` — all existing tests pass
- [x] `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)