### PR TITLE
feat: close feedback loop — wire up dead reinforcement counters

Add explicit and implicit feedback paths so the system can learn from
its own performance instead of operating in open-loop mode.

Changes:
- Add RecordFollowed/RecordConfirmed/RecordOverridden to SQLite store
  and MultiGraphStore (mirroring RecordActivationHit pattern)
- Add floop_feedback MCP tool for explicit confirmed/overridden signals
- Wire implicit confirmation into floop_active: behaviors persisting
  across consecutive calls get an automatic TimesConfirmed increment
- Update isViolated() to require feedback data before flagging and
  lower threshold to 40% (accounts for narrow-applicability behaviors)
- usageScore() now returns differentiated values when feedback exists

Tests cover all three recording methods, the updated violation logic,
and usage scoring with various feedback signal combinations.

https://claude.ai/code/session_016pFfHJZLW3BhCqGsDCvQ7Q

### DIFF
--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -211,3 +211,16 @@ type ValidationErrorOutput struct {
 	RefID      string `json:"ref_id" jsonschema:"The problematic referenced ID"`
 	Issue      string `json:"issue" jsonschema:"Issue type: dangling, cycle, or self-reference"`
 }
+
+// FloopFeedbackInput defines the input for floop_feedback tool.
+type FloopFeedbackInput struct {
+	BehaviorID string `json:"behavior_id" jsonschema:"ID of the behavior to provide feedback on,required"`
+	Signal     string `json:"signal" jsonschema:"Feedback signal: confirmed (behavior was helpful) or overridden (behavior was contradicted),required"`
+}
+
+// FloopFeedbackOutput defines the output for floop_feedback tool.
+type FloopFeedbackOutput struct {
+	BehaviorID string `json:"behavior_id" jsonschema:"ID of the behavior"`
+	Signal     string `json:"signal" jsonschema:"Feedback signal that was recorded"`
+	Message    string `json:"message" jsonschema:"Human-readable result message"`
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -53,6 +53,10 @@ type Server struct {
 	// Bounded worker pool for background goroutines
 	workerPool chan struct{}
 
+	// Feedback loop: track previously active behavior IDs for implicit confirmation
+	prevActiveMu sync.Mutex
+	prevActiveIDs map[string]struct{}
+
 	// Shutdown coordination
 	done      chan struct{} // closed on shutdown
 	closeOnce sync.Once
@@ -111,6 +115,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		backupConfig:    &floopCfg.Backup,
 		retentionPolicy: retPolicy,
 		workerPool:      make(chan struct{}, maxBackgroundWorkers),
+		prevActiveIDs:   make(map[string]struct{}),
 		done:            make(chan struct{}),
 	}
 

--- a/internal/store/multi.go
+++ b/internal/store/multi.go
@@ -431,6 +431,96 @@ func (m *MultiGraphStore) RecordActivationHit(ctx context.Context, behaviorID st
 	return fmt.Errorf("behavior not found in either store: %s", behaviorID)
 }
 
+// RecordFollowed delegates to whichever store contains the behavior.
+func (m *MultiGraphStore) RecordFollowed(ctx context.Context, behaviorID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Try local first
+	if localStore, ok := m.localStore.(*SQLiteGraphStore); ok {
+		localNode, err := m.localStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking local store: %w", err)
+		}
+		if localNode != nil {
+			return localStore.RecordFollowed(ctx, behaviorID)
+		}
+	}
+
+	// Try global
+	if globalStore, ok := m.globalStore.(*SQLiteGraphStore); ok {
+		globalNode, err := m.globalStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking global store: %w", err)
+		}
+		if globalNode != nil {
+			return globalStore.RecordFollowed(ctx, behaviorID)
+		}
+	}
+
+	return fmt.Errorf("behavior not found in either store: %s", behaviorID)
+}
+
+// RecordConfirmed delegates to whichever store contains the behavior.
+func (m *MultiGraphStore) RecordConfirmed(ctx context.Context, behaviorID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Try local first
+	if localStore, ok := m.localStore.(*SQLiteGraphStore); ok {
+		localNode, err := m.localStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking local store: %w", err)
+		}
+		if localNode != nil {
+			return localStore.RecordConfirmed(ctx, behaviorID)
+		}
+	}
+
+	// Try global
+	if globalStore, ok := m.globalStore.(*SQLiteGraphStore); ok {
+		globalNode, err := m.globalStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking global store: %w", err)
+		}
+		if globalNode != nil {
+			return globalStore.RecordConfirmed(ctx, behaviorID)
+		}
+	}
+
+	return fmt.Errorf("behavior not found in either store: %s", behaviorID)
+}
+
+// RecordOverridden delegates to whichever store contains the behavior.
+func (m *MultiGraphStore) RecordOverridden(ctx context.Context, behaviorID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Try local first
+	if localStore, ok := m.localStore.(*SQLiteGraphStore); ok {
+		localNode, err := m.localStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking local store: %w", err)
+		}
+		if localNode != nil {
+			return localStore.RecordOverridden(ctx, behaviorID)
+		}
+	}
+
+	// Try global
+	if globalStore, ok := m.globalStore.(*SQLiteGraphStore); ok {
+		globalNode, err := m.globalStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking global store: %w", err)
+		}
+		if globalNode != nil {
+			return globalStore.RecordOverridden(ctx, behaviorID)
+		}
+	}
+
+	return fmt.Errorf("behavior not found in either store: %s", behaviorID)
+}
+
 // TouchEdges delegates to both stores.
 func (m *MultiGraphStore) TouchEdges(ctx context.Context, behaviorIDs []string) error {
 	m.mu.Lock()

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1222,6 +1222,79 @@ func (s *SQLiteGraphStore) RecordActivationHit(ctx context.Context, behaviorID s
 	return nil
 }
 
+// RecordFollowed increments times_followed for a behavior.
+// This is called when the agent's output was consistent with the behavior.
+func (s *SQLiteGraphStore) RecordFollowed(ctx context.Context, behaviorID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE behavior_stats SET times_followed = times_followed + 1 WHERE behavior_id = ?`,
+		behaviorID)
+	if err != nil {
+		return fmt.Errorf("failed to record followed for %s: %w", behaviorID, err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("behavior not found: %s", behaviorID)
+	}
+
+	return nil
+}
+
+// RecordConfirmed increments times_confirmed and updates last_confirmed for a behavior.
+// This is called when the user explicitly confirms a behavior was helpful.
+func (s *SQLiteGraphStore) RecordConfirmed(ctx context.Context, behaviorID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now().Format(time.RFC3339)
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE behavior_stats SET times_confirmed = times_confirmed + 1, last_confirmed = ? WHERE behavior_id = ?`,
+		now, behaviorID)
+	if err != nil {
+		return fmt.Errorf("failed to record confirmed for %s: %w", behaviorID, err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("behavior not found: %s", behaviorID)
+	}
+
+	return nil
+}
+
+// RecordOverridden increments times_overridden for a behavior.
+// This is called when the user or agent contradicted the behavior.
+func (s *SQLiteGraphStore) RecordOverridden(ctx context.Context, behaviorID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE behavior_stats SET times_overridden = times_overridden + 1 WHERE behavior_id = ?`,
+		behaviorID)
+	if err != nil {
+		return fmt.Errorf("failed to record overridden for %s: %w", behaviorID, err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("behavior not found: %s", behaviorID)
+	}
+
+	return nil
+}
+
 // TouchEdges updates last_activated on all edges where the source or target
 // is one of the given behavior IDs. This enables temporal decay on edge
 // weights in the spreading activation engine.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1496,3 +1496,229 @@ func TestSQLiteStore_TouchEdges_Empty(t *testing.T) {
 		t.Errorf("TouchEdges(empty) error = %v, want nil", err)
 	}
 }
+
+func TestSQLiteStore_RecordFollowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := NewSQLiteGraphStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSQLiteGraphStore() error = %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+
+	// Add a behavior
+	_, err = s.AddNode(ctx, Node{
+		ID:   "follow-test",
+		Kind: "behavior",
+		Content: map[string]interface{}{
+			"name": "Follow Test",
+			"kind": "directive",
+			"content": map[string]interface{}{
+				"canonical": "Test follow recording",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddNode() error = %v", err)
+	}
+
+	// Record first follow
+	err = s.RecordFollowed(ctx, "follow-test")
+	if err != nil {
+		t.Fatalf("RecordFollowed() error = %v", err)
+	}
+
+	var timesFollowed int
+	err = s.db.QueryRowContext(ctx,
+		`SELECT times_followed FROM behavior_stats WHERE behavior_id = ?`,
+		"follow-test").Scan(&timesFollowed)
+	if err != nil {
+		t.Fatalf("query stats error = %v", err)
+	}
+	if timesFollowed != 1 {
+		t.Errorf("times_followed = %d, want 1", timesFollowed)
+	}
+
+	// Record second follow
+	err = s.RecordFollowed(ctx, "follow-test")
+	if err != nil {
+		t.Fatalf("RecordFollowed() second call error = %v", err)
+	}
+
+	err = s.db.QueryRowContext(ctx,
+		`SELECT times_followed FROM behavior_stats WHERE behavior_id = ?`,
+		"follow-test").Scan(&timesFollowed)
+	if err != nil {
+		t.Fatalf("query stats error = %v", err)
+	}
+	if timesFollowed != 2 {
+		t.Errorf("times_followed = %d, want 2", timesFollowed)
+	}
+}
+
+func TestSQLiteStore_RecordFollowed_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := NewSQLiteGraphStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSQLiteGraphStore() error = %v", err)
+	}
+	defer s.Close()
+
+	err = s.RecordFollowed(context.Background(), "nonexistent-id")
+	if err == nil {
+		t.Error("RecordFollowed() expected error for nonexistent behavior")
+	}
+}
+
+func TestSQLiteStore_RecordConfirmed(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := NewSQLiteGraphStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSQLiteGraphStore() error = %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+
+	// Add a behavior
+	_, err = s.AddNode(ctx, Node{
+		ID:   "confirm-test",
+		Kind: "behavior",
+		Content: map[string]interface{}{
+			"name": "Confirm Test",
+			"kind": "directive",
+			"content": map[string]interface{}{
+				"canonical": "Test confirm recording",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddNode() error = %v", err)
+	}
+
+	// Record confirmation
+	err = s.RecordConfirmed(ctx, "confirm-test")
+	if err != nil {
+		t.Fatalf("RecordConfirmed() error = %v", err)
+	}
+
+	var timesConfirmed int
+	var lastConfirmed sql.NullString
+	err = s.db.QueryRowContext(ctx,
+		`SELECT times_confirmed, last_confirmed FROM behavior_stats WHERE behavior_id = ?`,
+		"confirm-test").Scan(&timesConfirmed, &lastConfirmed)
+	if err != nil {
+		t.Fatalf("query stats error = %v", err)
+	}
+	if timesConfirmed != 1 {
+		t.Errorf("times_confirmed = %d, want 1", timesConfirmed)
+	}
+	if !lastConfirmed.Valid {
+		t.Error("last_confirmed should be set after first confirmation")
+	}
+
+	// Record second confirmation
+	err = s.RecordConfirmed(ctx, "confirm-test")
+	if err != nil {
+		t.Fatalf("RecordConfirmed() second call error = %v", err)
+	}
+
+	err = s.db.QueryRowContext(ctx,
+		`SELECT times_confirmed FROM behavior_stats WHERE behavior_id = ?`,
+		"confirm-test").Scan(&timesConfirmed)
+	if err != nil {
+		t.Fatalf("query stats error = %v", err)
+	}
+	if timesConfirmed != 2 {
+		t.Errorf("times_confirmed = %d, want 2", timesConfirmed)
+	}
+}
+
+func TestSQLiteStore_RecordConfirmed_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := NewSQLiteGraphStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSQLiteGraphStore() error = %v", err)
+	}
+	defer s.Close()
+
+	err = s.RecordConfirmed(context.Background(), "nonexistent-id")
+	if err == nil {
+		t.Error("RecordConfirmed() expected error for nonexistent behavior")
+	}
+}
+
+func TestSQLiteStore_RecordOverridden(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := NewSQLiteGraphStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSQLiteGraphStore() error = %v", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+
+	// Add a behavior
+	_, err = s.AddNode(ctx, Node{
+		ID:   "override-test",
+		Kind: "behavior",
+		Content: map[string]interface{}{
+			"name": "Override Test",
+			"kind": "directive",
+			"content": map[string]interface{}{
+				"canonical": "Test override recording",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("AddNode() error = %v", err)
+	}
+
+	// Record override
+	err = s.RecordOverridden(ctx, "override-test")
+	if err != nil {
+		t.Fatalf("RecordOverridden() error = %v", err)
+	}
+
+	var timesOverridden int
+	err = s.db.QueryRowContext(ctx,
+		`SELECT times_overridden FROM behavior_stats WHERE behavior_id = ?`,
+		"override-test").Scan(&timesOverridden)
+	if err != nil {
+		t.Fatalf("query stats error = %v", err)
+	}
+	if timesOverridden != 1 {
+		t.Errorf("times_overridden = %d, want 1", timesOverridden)
+	}
+
+	// Record second override
+	err = s.RecordOverridden(ctx, "override-test")
+	if err != nil {
+		t.Fatalf("RecordOverridden() second call error = %v", err)
+	}
+
+	err = s.db.QueryRowContext(ctx,
+		`SELECT times_overridden FROM behavior_stats WHERE behavior_id = ?`,
+		"override-test").Scan(&timesOverridden)
+	if err != nil {
+		t.Fatalf("query stats error = %v", err)
+	}
+	if timesOverridden != 2 {
+		t.Errorf("times_overridden = %d, want 2", timesOverridden)
+	}
+}
+
+func TestSQLiteStore_RecordOverridden_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	s, err := NewSQLiteGraphStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSQLiteGraphStore() error = %v", err)
+	}
+	defer s.Close()
+
+	err = s.RecordOverridden(context.Background(), "nonexistent-id")
+	if err == nil {
+		t.Error("RecordOverridden() expected error for nonexistent behavior")
+	}
+}


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why? -->

## Related Issue

<!-- Fixes #123 or Closes #123 -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (describe below)

## Testing

<!-- How was this tested? -->

## Checklist

- [ ] `make ci` passes
- [ ] Tests added/updated for changes
- [ ] Documentation updated if needed
