### PR TITLE
feat: close feedback loop — wire dead reinforcement counters

### DIFF
--- a/internal/mcp/audit.go
+++ b/internal/mcp/audit.go
@@ -168,6 +168,7 @@ func sanitizeToolParams(toolName string, params map[string]interface{}) map[stri
 		"kind":          true,
 		"tag":           true,
 		"corrections":   true,
+		"signal":        true,
 	}
 
 	// Parameters whose existence is safe to log but whose values may contain
@@ -183,6 +184,7 @@ func sanitizeToolParams(toolName string, params map[string]interface{}) map[stri
 		"output_path": true,
 		"weight":      true,
 		"auto_merge":  true,
+		"behavior_id": true,
 	}
 
 	for key, val := range params {

--- a/internal/mcp/schema.go
+++ b/internal/mcp/schema.go
@@ -211,3 +211,16 @@ type ValidationErrorOutput struct {
 	RefID      string `json:"ref_id" jsonschema:"The problematic referenced ID"`
 	Issue      string `json:"issue" jsonschema:"Issue type: dangling, cycle, or self-reference"`
 }
+
+// FloopFeedbackInput defines the input for floop_feedback tool.
+type FloopFeedbackInput struct {
+	BehaviorID string `json:"behavior_id" jsonschema:"ID of the behavior to provide feedback on,required"`
+	Signal     string `json:"signal" jsonschema:"Feedback signal: confirmed (behavior was helpful) or overridden (behavior was contradicted),required"`
+}
+
+// FloopFeedbackOutput defines the output for floop_feedback tool.
+type FloopFeedbackOutput struct {
+	BehaviorID string `json:"behavior_id" jsonschema:"ID of the behavior"`
+	Signal     string `json:"signal" jsonschema:"Feedback signal that was recorded"`
+	Message    string `json:"message" jsonschema:"Human-readable result message"`
+}

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -87,6 +87,7 @@ func NewToolLimiters() ToolLimiters {
 		"floop_list":        NewLimiter(1.0, 10),      // 60/minute, burst 10
 		"floop_validate":    NewLimiter(10.0/60.0, 5), // 10/minute, burst 5
 		"floop_graph":       NewLimiter(30.0/60.0, 5), // 30/minute, burst 5
+		"floop_feedback":    NewLimiter(30.0/60.0, 5), // 30/minute, burst 5
 	}
 }
 

--- a/internal/store/multi.go
+++ b/internal/store/multi.go
@@ -431,6 +431,66 @@ func (m *MultiGraphStore) RecordActivationHit(ctx context.Context, behaviorID st
 	return fmt.Errorf("behavior not found in either store: %s", behaviorID)
 }
 
+// RecordConfirmed delegates to whichever store contains the behavior.
+func (m *MultiGraphStore) RecordConfirmed(ctx context.Context, behaviorID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Try local first
+	if localStore, ok := m.localStore.(*SQLiteGraphStore); ok {
+		localNode, err := m.localStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking local store: %w", err)
+		}
+		if localNode != nil {
+			return localStore.RecordConfirmed(ctx, behaviorID)
+		}
+	}
+
+	// Try global
+	if globalStore, ok := m.globalStore.(*SQLiteGraphStore); ok {
+		globalNode, err := m.globalStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking global store: %w", err)
+		}
+		if globalNode != nil {
+			return globalStore.RecordConfirmed(ctx, behaviorID)
+		}
+	}
+
+	return fmt.Errorf("behavior not found in either store: %s", behaviorID)
+}
+
+// RecordOverridden delegates to whichever store contains the behavior.
+func (m *MultiGraphStore) RecordOverridden(ctx context.Context, behaviorID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Try local first
+	if localStore, ok := m.localStore.(*SQLiteGraphStore); ok {
+		localNode, err := m.localStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking local store: %w", err)
+		}
+		if localNode != nil {
+			return localStore.RecordOverridden(ctx, behaviorID)
+		}
+	}
+
+	// Try global
+	if globalStore, ok := m.globalStore.(*SQLiteGraphStore); ok {
+		globalNode, err := m.globalStore.GetNode(ctx, behaviorID)
+		if err != nil {
+			return fmt.Errorf("error checking global store: %w", err)
+		}
+		if globalNode != nil {
+			return globalStore.RecordOverridden(ctx, behaviorID)
+		}
+	}
+
+	return fmt.Errorf("behavior not found in either store: %s", behaviorID)
+}
+
 // TouchEdges delegates to both stores.
 func (m *MultiGraphStore) TouchEdges(ctx context.Context, behaviorIDs []string) error {
 	m.mu.Lock()


### PR DESCRIPTION
## Summary
- Add session-scoped implicit confirmation: each behavior gets at most 1 `TimesConfirmed` increment per MCP session (not per `floop_active` call), measuring "how many distinct work sessions involved this behavior"
- Add explicit `floop_feedback` MCP tool for agents to signal `confirmed` or `overridden` on specific behaviors
- Fix `isViolated()` and `usageScore()` to use `totalFeedback` (followed+confirmed+overridden) as denominator instead of `TimesActivated`, with minimum sample size of 3
- Add rate limiter for `floop_feedback` (30/min, burst 5) and audit whitelist entries for `behavior_id`/`signal`
- Remove dead `RecordFollowed` code (semantics indistinguishable from `RecordConfirmed`)
- Add `RecordConfirmed`/`RecordOverridden` store methods with multi-store delegation

## Test plan
- [x] `TestHandleFloopFeedback` — confirmed/overridden/invalid signal/not found
- [x] `TestIsViolated` — 8 cases: no feedback, below min sample, at threshold, violated, confirmed-as-positive
- [x] `TestUsageScore_WithFeedback` — 5 cases: below min sample, all positive/negative, mixed, confirmed counts
- [x] `TestSQLiteStore_RecordConfirmed` / `RecordOverridden` — increment counters, not-found error
- [x] `go test ./...` — all 27 packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)