### PR TITLE
feat: Oja-stabilized Hebbian co-activation edge learning

### DIFF
--- a/internal/mcp/hebbian.go
+++ b/internal/mcp/hebbian.go
@@ -1,0 +1,151 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/nvandessel/feedback-loop/internal/spreading"
+	"github.com/nvandessel/feedback-loop/internal/store"
+)
+
+// coActivatedEdgeKind is the edge kind used for Hebbian co-activation edges.
+const coActivatedEdgeKind = "co-activated"
+
+// coActivationTracker tracks co-activation counts between behavior pairs.
+// It gates edge creation: a new co-activated edge is only created after
+// CreationGate co-occurrences within CreationWindow.
+type coActivationTracker struct {
+	mu      sync.Mutex
+	entries map[string][]time.Time // key: "behaviorA:behaviorB" → timestamps of co-activations
+}
+
+// newCoActivationTracker creates a new co-activation tracker.
+func newCoActivationTracker() *coActivationTracker {
+	return &coActivationTracker{
+		entries: make(map[string][]time.Time),
+	}
+}
+
+// pairKey returns a canonical key for a behavior pair.
+// Assumes behaviorA < behaviorB (caller ensures canonical ordering).
+func pairKey(behaviorA, behaviorB string) string {
+	return behaviorA + ":" + behaviorB
+}
+
+// record records a co-activation and returns whether the pair has met the
+// creation gate threshold within the creation window.
+func (t *coActivationTracker) record(pair spreading.CoActivationPair, cfg spreading.HebbianConfig) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := pairKey(pair.BehaviorA, pair.BehaviorB)
+	now := time.Now()
+
+	// Append and expire old entries outside the window
+	entries := t.entries[key]
+	cutoff := now.Add(-cfg.CreationWindow)
+	fresh := make([]time.Time, 0, len(entries)+1)
+	for _, ts := range entries {
+		if ts.After(cutoff) {
+			fresh = append(fresh, ts)
+		}
+	}
+	fresh = append(fresh, now)
+	t.entries[key] = fresh
+
+	return len(fresh) >= cfg.CreationGate
+}
+
+// applyHebbianUpdates processes co-activation pairs from a single floop_active
+// call. For each pair:
+//   - If no co-activated edge exists and the creation gate hasn't been met,
+//     just record the co-occurrence.
+//   - If the creation gate is met, create the edge with initial weight.
+//   - If the edge already exists, apply Oja's rule to update the weight.
+//
+// After all updates, prune edges whose weight has decayed below MinWeight.
+func (s *Server) applyHebbianUpdates(
+	ctx context.Context,
+	pairs []spreading.CoActivationPair,
+	cfg spreading.HebbianConfig,
+) {
+	if len(pairs) == 0 {
+		return
+	}
+
+	// Duck-typed interfaces for batch operations
+	type edgeWeightUpdater interface {
+		BatchUpdateEdgeWeights(ctx context.Context, updates []store.EdgeWeightUpdate) error
+	}
+	type edgePruner interface {
+		PruneWeakEdges(ctx context.Context, kind string, threshold float64) (int, error)
+	}
+
+	var weightUpdates []store.EdgeWeightUpdate
+
+	for _, pair := range pairs {
+		// Check if edge already exists
+		edges, err := s.store.GetEdges(ctx, pair.BehaviorA, store.DirectionOutbound, coActivatedEdgeKind)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: hebbian: get edges for %s: %v\n", pair.BehaviorA, err)
+			continue
+		}
+
+		var existing *store.Edge
+		for i := range edges {
+			if edges[i].Target == pair.BehaviorB {
+				existing = &edges[i]
+				break
+			}
+		}
+
+		if existing != nil {
+			// Edge exists — apply Oja update
+			newWeight := spreading.OjaUpdate(existing.Weight, pair.ActivationA, pair.ActivationB, cfg)
+			weightUpdates = append(weightUpdates, store.EdgeWeightUpdate{
+				Source:    pair.BehaviorA,
+				Target:    pair.BehaviorB,
+				Kind:      coActivatedEdgeKind,
+				NewWeight: newWeight,
+			})
+		} else {
+			// No edge yet — check creation gate
+			if s.coActivationTracker.record(pair, cfg) {
+				// Gate met — create new edge with initial weight from Oja
+				initialWeight := spreading.OjaUpdate(0.1, pair.ActivationA, pair.ActivationB, cfg)
+				err := s.store.AddEdge(ctx, store.Edge{
+					Source:    pair.BehaviorA,
+					Target:    pair.BehaviorB,
+					Kind:      coActivatedEdgeKind,
+					Weight:    initialWeight,
+					CreatedAt: time.Now(),
+				})
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "warning: hebbian: create edge %s→%s: %v\n",
+						pair.BehaviorA, pair.BehaviorB, err)
+				}
+			}
+		}
+	}
+
+	// Batch update existing edge weights
+	if len(weightUpdates) > 0 {
+		if updater, ok := s.store.(edgeWeightUpdater); ok {
+			if err := updater.BatchUpdateEdgeWeights(ctx, weightUpdates); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: hebbian: batch update weights: %v\n", err)
+			}
+		}
+	}
+
+	// Prune edges whose weight has decayed below MinWeight
+	if pruner, ok := s.store.(edgePruner); ok {
+		if n, err := pruner.PruneWeakEdges(ctx, coActivatedEdgeKind, cfg.MinWeight); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: hebbian: prune weak edges: %v\n", err)
+		} else if n > 0 {
+			fmt.Fprintf(os.Stderr, "floop: pruned %d weak co-activated edge(s)\n", n)
+		}
+	}
+}

--- a/internal/mcp/hebbian_test.go
+++ b/internal/mcp/hebbian_test.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nvandessel/feedback-loop/internal/spreading"
+)
+
+func TestCoActivationTracker_Record(t *testing.T) {
+	tracker := newCoActivationTracker()
+	cfg := spreading.DefaultHebbianConfig()
+	cfg.CreationGate = 3
+	cfg.CreationWindow = 1 * time.Hour
+
+	pair := spreading.CoActivationPair{
+		BehaviorA:   "a",
+		BehaviorB:   "b",
+		ActivationA: 0.8,
+		ActivationB: 0.7,
+	}
+
+	// First two recordings: gate not met
+	if tracker.record(pair, cfg) {
+		t.Error("gate should not be met after 1 recording")
+	}
+	if tracker.record(pair, cfg) {
+		t.Error("gate should not be met after 2 recordings")
+	}
+
+	// Third recording: gate met
+	if !tracker.record(pair, cfg) {
+		t.Error("gate should be met after 3 recordings")
+	}
+}
+
+func TestCoActivationTracker_WindowExpiry(t *testing.T) {
+	tracker := newCoActivationTracker()
+	cfg := spreading.DefaultHebbianConfig()
+	cfg.CreationGate = 3
+	cfg.CreationWindow = 1 * time.Hour
+
+	pair := spreading.CoActivationPair{
+		BehaviorA:   "a",
+		BehaviorB:   "b",
+		ActivationA: 0.8,
+		ActivationB: 0.7,
+	}
+
+	key := pairKey(pair.BehaviorA, pair.BehaviorB)
+
+	// Simulate 2 old recordings (outside window)
+	tracker.mu.Lock()
+	tracker.entries[key] = []time.Time{
+		time.Now().Add(-2 * time.Hour),
+		time.Now().Add(-90 * time.Minute),
+	}
+	tracker.mu.Unlock()
+
+	// These should be expired, so recording should start fresh
+	if tracker.record(pair, cfg) {
+		t.Error("expired entries should not count toward gate")
+	}
+	if tracker.record(pair, cfg) {
+		t.Error("gate should not be met after 2 fresh recordings")
+	}
+	if !tracker.record(pair, cfg) {
+		t.Error("gate should be met after 3 fresh recordings")
+	}
+}
+
+func TestCoActivationTracker_DifferentPairs(t *testing.T) {
+	tracker := newCoActivationTracker()
+	cfg := spreading.DefaultHebbianConfig()
+	cfg.CreationGate = 3
+
+	pairAB := spreading.CoActivationPair{BehaviorA: "a", BehaviorB: "b"}
+	pairAC := spreading.CoActivationPair{BehaviorA: "a", BehaviorB: "c"}
+
+	// Record AB twice, AC once
+	tracker.record(pairAB, cfg)
+	tracker.record(pairAC, cfg)
+	tracker.record(pairAB, cfg)
+
+	// Third AB should trigger gate; AC has only 1 recording
+	if !tracker.record(pairAB, cfg) {
+		t.Error("AB gate should be met after 3 recordings")
+	}
+	if tracker.record(pairAC, cfg) {
+		t.Error("AC gate should not be met after only 2 recordings")
+	}
+}
+
+func TestPairKey_Canonical(t *testing.T) {
+	k1 := pairKey("alpha", "beta")
+	k2 := pairKey("alpha", "beta")
+	if k1 != k2 {
+		t.Errorf("same inputs should produce same key: %s != %s", k1, k2)
+	}
+
+	k3 := pairKey("beta", "alpha")
+	if k1 == k3 {
+		t.Log("note: pairKey is NOT symmetric — caller must ensure canonical order")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nvandessel/feedback-loop/internal/ratelimit"
 	"github.com/nvandessel/feedback-loop/internal/seed"
 	"github.com/nvandessel/feedback-loop/internal/session"
+	"github.com/nvandessel/feedback-loop/internal/spreading"
 	"github.com/nvandessel/feedback-loop/internal/store"
 )
 
@@ -56,6 +57,10 @@ type Server struct {
 	// involved this behavior" — a far better usefulness proxy than per-call counting.
 	confirmedSessionMu   sync.Mutex
 	confirmedThisSession map[string]struct{}
+
+	// Hebbian co-activation learning
+	coActivationTracker *coActivationTracker
+	hebbianConfig       spreading.HebbianConfig
 
 	// Shutdown coordination
 	done      chan struct{} // closed on shutdown
@@ -115,6 +120,8 @@ func NewServer(cfg *Config) (*Server, error) {
 		retentionPolicy:      retPolicy,
 		workerPool:           make(chan struct{}, maxBackgroundWorkers),
 		confirmedThisSession: make(map[string]struct{}),
+		coActivationTracker:  newCoActivationTracker(),
+		hebbianConfig:        spreading.DefaultHebbianConfig(),
 		done:                 make(chan struct{}),
 	}
 

--- a/internal/spreading/hebbian.go
+++ b/internal/spreading/hebbian.go
@@ -1,0 +1,136 @@
+package spreading
+
+import (
+	"math"
+	"time"
+)
+
+// HebbianConfig configures Oja-stabilized Hebbian co-activation learning.
+type HebbianConfig struct {
+	// LearningRate (eta) controls how fast edge weights adapt. Default: 0.05.
+	// Oja's rule is self-limiting, so a fixed rate works well.
+	LearningRate float64
+
+	// MinWeight is the floor for edge weights. Default: 0.01.
+	// Edges below this are candidates for pruning.
+	MinWeight float64
+
+	// MaxWeight is the ceiling for edge weights. Default: 0.95.
+	// Prevents co-activated edges from dominating semantic edges.
+	MaxWeight float64
+
+	// ActivationThreshold is the minimum activation for a behavior to be
+	// included in co-activation pairs. Default: 0.3 (sigmoid inflection).
+	ActivationThreshold float64
+
+	// CreationGate is the number of co-occurrences required within
+	// CreationWindow before a new co-activated edge is created. Default: 3.
+	CreationGate int
+
+	// CreationWindow is the time window for counting co-occurrences. Default: 7 days.
+	CreationWindow time.Duration
+}
+
+// DefaultHebbianConfig returns the default Hebbian learning configuration.
+func DefaultHebbianConfig() HebbianConfig {
+	return HebbianConfig{
+		LearningRate:        0.05,
+		MinWeight:           0.01,
+		MaxWeight:           0.95,
+		ActivationThreshold: 0.3,
+		CreationGate:        3,
+		CreationWindow:      7 * 24 * time.Hour,
+	}
+}
+
+// CoActivationPair represents two behaviors that were co-activated.
+type CoActivationPair struct {
+	BehaviorA   string  // First behavior ID
+	BehaviorB   string  // Second behavior ID
+	ActivationA float64 // Activation level of A
+	ActivationB float64 // Activation level of B
+}
+
+// OjaUpdate computes the new edge weight using Oja's rule.
+//
+// Oja's rule: dW = eta * (A_i * A_j - A_j^2 * W)
+//
+// The A_j^2 * W term is the forgetting factor that prevents unbounded weight
+// growth. The weight norm converges to 1.0 naturally, which is critical —
+// naive Hebbian learning causes runaway clustering in spreading activation
+// networks.
+//
+// The result is clamped to [minWeight, maxWeight].
+func OjaUpdate(currentWeight, activationA, activationB float64, cfg HebbianConfig) float64 {
+	// Oja's rule: dW = eta * (A_i * A_j - A_j^2 * W)
+	hebbian := activationA * activationB
+	forgetting := activationB * activationB * currentWeight
+	dw := cfg.LearningRate * (hebbian - forgetting)
+
+	newWeight := currentWeight + dw
+	return clampWeight(newWeight, cfg.MinWeight, cfg.MaxWeight)
+}
+
+// ExtractCoActivationPairs identifies pairs of behaviors that were
+// co-activated above the threshold. Only pairs where both members
+// exceed the activation threshold are included.
+//
+// seedIDs is the set of seed behavior IDs. Pairs where BOTH members
+// are seeds are excluded — seed co-activation reflects context matching,
+// not behavioral affinity.
+func ExtractCoActivationPairs(results []Result, seedIDs map[string]bool, cfg HebbianConfig) []CoActivationPair {
+	// Filter to behaviors above threshold
+	active := make([]Result, 0, len(results))
+	for _, r := range results {
+		if r.Activation >= cfg.ActivationThreshold {
+			active = append(active, r)
+		}
+	}
+
+	if len(active) < 2 {
+		return nil
+	}
+
+	// Generate all unique pairs, excluding seed-seed pairs
+	pairs := make([]CoActivationPair, 0, len(active)*(len(active)-1)/2)
+	for i := 0; i < len(active); i++ {
+		for j := i + 1; j < len(active); j++ {
+			aIsSeed := seedIDs[active[i].BehaviorID]
+			bIsSeed := seedIDs[active[j].BehaviorID]
+
+			// Skip pairs where both are seeds
+			if aIsSeed && bIsSeed {
+				continue
+			}
+
+			// Canonical ordering: smaller ID first
+			a, b := active[i], active[j]
+			if a.BehaviorID > b.BehaviorID {
+				a, b = b, a
+			}
+
+			pairs = append(pairs, CoActivationPair{
+				BehaviorA:   a.BehaviorID,
+				BehaviorB:   b.BehaviorID,
+				ActivationA: a.Activation,
+				ActivationB: b.Activation,
+			})
+		}
+	}
+
+	return pairs
+}
+
+// clampWeight restricts a weight to [min, max].
+func clampWeight(w, min, max float64) float64 {
+	if math.IsNaN(w) || math.IsInf(w, 0) {
+		return min
+	}
+	if w < min {
+		return min
+	}
+	if w > max {
+		return max
+	}
+	return w
+}

--- a/internal/spreading/hebbian_test.go
+++ b/internal/spreading/hebbian_test.go
@@ -1,0 +1,312 @@
+package spreading
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestOjaUpdate_BasicStrengthening(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+
+	// Two co-activated behaviors should strengthen their edge
+	oldWeight := 0.5
+	newWeight := OjaUpdate(oldWeight, 0.8, 0.8, cfg)
+
+	if newWeight <= oldWeight {
+		t.Errorf("co-activation should strengthen: old=%f, new=%f", oldWeight, newWeight)
+	}
+}
+
+func TestOjaUpdate_SelfLimiting(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+
+	// Oja's rule is self-limiting: weight should converge, not grow unbounded.
+	// Run 1000 iterations with constant activation.
+	w := 0.1
+	for i := 0; i < 1000; i++ {
+		w = OjaUpdate(w, 0.8, 0.8, cfg)
+	}
+
+	// Weight should converge to activationA/activationB = 1.0 (clamped to MaxWeight)
+	// but should NOT exceed MaxWeight
+	if w > cfg.MaxWeight {
+		t.Errorf("weight %f exceeds MaxWeight %f after 1000 iterations", w, cfg.MaxWeight)
+	}
+	if w < 0.5 {
+		t.Errorf("weight %f should converge to a high value, not stay low", w)
+	}
+}
+
+func TestOjaUpdate_Convergence(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	cfg.MaxWeight = 1.0 // Remove ceiling to test pure Oja convergence
+
+	// With equal activations (A=B=x), Oja converges to w = A/B = 1.0
+	w := 0.1
+	for i := 0; i < 2000; i++ {
+		w = OjaUpdate(w, 0.6, 0.6, cfg)
+	}
+
+	// Should converge near 1.0 (the ratio A_i/A_j when A_i == A_j)
+	if math.Abs(w-1.0) > 0.01 {
+		t.Errorf("weight should converge to 1.0, got %f", w)
+	}
+}
+
+func TestOjaUpdate_AsymmetricActivation(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	cfg.MaxWeight = 2.0 // High ceiling to test convergence target
+
+	// With A_i=0.8, A_j=0.4, Oja converges to w = A_i/A_j = 2.0
+	w := 0.1
+	for i := 0; i < 5000; i++ {
+		w = OjaUpdate(w, 0.8, 0.4, cfg)
+	}
+
+	// Should converge near A_i/A_j = 0.8/0.4 = 2.0
+	if math.Abs(w-2.0) > 0.05 {
+		t.Errorf("weight should converge to 2.0, got %f", w)
+	}
+}
+
+func TestOjaUpdate_WeakensOnLowActivation(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+
+	// When forgetting term dominates (A_j^2 * W > A_i * A_j), Oja weakens.
+	// With A_i=0.1, A_j=0.5, W=0.9: forgetting=0.25*0.9=0.225 > hebbian=0.05
+	oldWeight := 0.9
+	newWeight := OjaUpdate(oldWeight, 0.1, 0.5, cfg)
+
+	if newWeight >= oldWeight {
+		t.Errorf("forgetting should dominate: old=%f, new=%f", oldWeight, newWeight)
+	}
+}
+
+func TestOjaUpdate_Clamping(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+
+	tests := []struct {
+		name       string
+		current    float64
+		actA, actB float64
+		wantMin    float64
+		wantMax    float64
+	}{
+		{
+			name:    "clamp to MinWeight",
+			current: 0.01,
+			actA:    0.0,
+			actB:    0.0,
+			wantMin: cfg.MinWeight,
+			wantMax: cfg.MinWeight,
+		},
+		{
+			name:    "clamp to MaxWeight",
+			current: 0.96, // Above MaxWeight → will be clamped
+			actA:    1.0,
+			actB:    1.0,
+			wantMin: cfg.MaxWeight,
+			wantMax: cfg.MaxWeight,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := OjaUpdate(tt.current, tt.actA, tt.actB, cfg)
+			if got < tt.wantMin || got > tt.wantMax {
+				t.Errorf("OjaUpdate(%f, %f, %f) = %f, want in [%f, %f]",
+					tt.current, tt.actA, tt.actB, got, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestOjaUpdate_NaN(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	got := OjaUpdate(math.NaN(), 0.5, 0.5, cfg)
+	if math.IsNaN(got) || math.IsInf(got, 0) {
+		t.Errorf("NaN input should produce clamped output, got %f", got)
+	}
+}
+
+func TestOjaUpdate_AntiAntMill(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+
+	// Triangle stability test: 3 behaviors with equal activation.
+	// No single edge should dominate after convergence.
+	wAB := 0.3
+	wBC := 0.3
+	wAC := 0.3
+	act := 0.7 // Equal activation for all
+
+	for i := 0; i < 500; i++ {
+		wAB = OjaUpdate(wAB, act, act, cfg)
+		wBC = OjaUpdate(wBC, act, act, cfg)
+		wAC = OjaUpdate(wAC, act, act, cfg)
+	}
+
+	// All edges should converge to similar values (within 1%)
+	if math.Abs(wAB-wBC) > 0.01 {
+		t.Errorf("anti-ant-mill: wAB=%f, wBC=%f should be equal", wAB, wBC)
+	}
+	if math.Abs(wAB-wAC) > 0.01 {
+		t.Errorf("anti-ant-mill: wAB=%f, wAC=%f should be equal", wAB, wAC)
+	}
+}
+
+func TestExtractCoActivationPairs_Basic(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	cfg.ActivationThreshold = 0.3
+
+	results := []Result{
+		{BehaviorID: "a", Activation: 0.8},
+		{BehaviorID: "b", Activation: 0.6},
+		{BehaviorID: "c", Activation: 0.1}, // Below threshold
+	}
+
+	pairs := ExtractCoActivationPairs(results, nil, cfg)
+
+	if len(pairs) != 1 {
+		t.Fatalf("expected 1 pair, got %d", len(pairs))
+	}
+	if pairs[0].BehaviorA != "a" || pairs[0].BehaviorB != "b" {
+		t.Errorf("expected pair (a,b), got (%s,%s)", pairs[0].BehaviorA, pairs[0].BehaviorB)
+	}
+}
+
+func TestExtractCoActivationPairs_CanonicalOrder(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	cfg.ActivationThreshold = 0.3
+
+	// Results in reverse alphabetical order
+	results := []Result{
+		{BehaviorID: "z", Activation: 0.8},
+		{BehaviorID: "a", Activation: 0.6},
+	}
+
+	pairs := ExtractCoActivationPairs(results, nil, cfg)
+
+	if len(pairs) != 1 {
+		t.Fatalf("expected 1 pair, got %d", len(pairs))
+	}
+	// Should be canonical: a before z
+	if pairs[0].BehaviorA != "a" || pairs[0].BehaviorB != "z" {
+		t.Errorf("expected canonical order (a,z), got (%s,%s)", pairs[0].BehaviorA, pairs[0].BehaviorB)
+	}
+}
+
+func TestExtractCoActivationPairs_ExcludeSeedSeedPairs(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	cfg.ActivationThreshold = 0.3
+
+	results := []Result{
+		{BehaviorID: "seed1", Activation: 0.9},
+		{BehaviorID: "seed2", Activation: 0.8},
+		{BehaviorID: "spread1", Activation: 0.7},
+	}
+
+	seedIDs := map[string]bool{
+		"seed1": true,
+		"seed2": true,
+	}
+
+	pairs := ExtractCoActivationPairs(results, seedIDs, cfg)
+
+	// seed1-seed2 should be excluded (both seeds)
+	// seed1-spread1 and seed2-spread1 should be included
+	if len(pairs) != 2 {
+		t.Fatalf("expected 2 pairs (excluding seed-seed), got %d", len(pairs))
+	}
+
+	// Verify no seed-seed pair exists
+	for _, p := range pairs {
+		if seedIDs[p.BehaviorA] && seedIDs[p.BehaviorB] {
+			t.Errorf("seed-seed pair should be excluded: (%s, %s)", p.BehaviorA, p.BehaviorB)
+		}
+	}
+}
+
+func TestExtractCoActivationPairs_TooFewActive(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	cfg.ActivationThreshold = 0.5
+
+	results := []Result{
+		{BehaviorID: "a", Activation: 0.8},
+		{BehaviorID: "b", Activation: 0.2}, // Below threshold
+	}
+
+	pairs := ExtractCoActivationPairs(results, nil, cfg)
+
+	if len(pairs) != 0 {
+		t.Errorf("expected 0 pairs when only 1 active, got %d", len(pairs))
+	}
+}
+
+func TestExtractCoActivationPairs_MultiplePairs(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+	cfg.ActivationThreshold = 0.3
+
+	results := []Result{
+		{BehaviorID: "a", Activation: 0.8},
+		{BehaviorID: "b", Activation: 0.7},
+		{BehaviorID: "c", Activation: 0.6},
+	}
+
+	pairs := ExtractCoActivationPairs(results, nil, cfg)
+
+	// 3 behaviors => 3 pairs: (a,b), (a,c), (b,c)
+	if len(pairs) != 3 {
+		t.Fatalf("expected 3 pairs, got %d", len(pairs))
+	}
+}
+
+func TestDefaultHebbianConfig(t *testing.T) {
+	cfg := DefaultHebbianConfig()
+
+	if cfg.LearningRate != 0.05 {
+		t.Errorf("LearningRate = %f, want 0.05", cfg.LearningRate)
+	}
+	if cfg.MinWeight != 0.01 {
+		t.Errorf("MinWeight = %f, want 0.01", cfg.MinWeight)
+	}
+	if cfg.MaxWeight != 0.95 {
+		t.Errorf("MaxWeight = %f, want 0.95", cfg.MaxWeight)
+	}
+	if cfg.ActivationThreshold != 0.3 {
+		t.Errorf("ActivationThreshold = %f, want 0.3", cfg.ActivationThreshold)
+	}
+	if cfg.CreationGate != 3 {
+		t.Errorf("CreationGate = %d, want 3", cfg.CreationGate)
+	}
+	if cfg.CreationWindow != 7*24*time.Hour {
+		t.Errorf("CreationWindow = %v, want 7 days", cfg.CreationWindow)
+	}
+}
+
+func TestClampWeight(t *testing.T) {
+	tests := []struct {
+		name string
+		w    float64
+		min  float64
+		max  float64
+		want float64
+	}{
+		{"in range", 0.5, 0.01, 0.95, 0.5},
+		{"below min", -0.1, 0.01, 0.95, 0.01},
+		{"above max", 1.5, 0.01, 0.95, 0.95},
+		{"NaN", math.NaN(), 0.01, 0.95, 0.01},
+		{"Inf", math.Inf(1), 0.01, 0.95, 0.01},
+		{"-Inf", math.Inf(-1), 0.01, 0.95, 0.01},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clampWeight(tt.w, tt.min, tt.max)
+			if got != tt.want {
+				t.Errorf("clampWeight(%f, %f, %f) = %f, want %f",
+					tt.w, tt.min, tt.max, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,6 +26,14 @@ type Edge struct {
 	Metadata      map[string]interface{} `json:"metadata,omitempty"`
 }
 
+// EdgeWeightUpdate describes a weight update for a specific edge.
+type EdgeWeightUpdate struct {
+	Source    string  // Source behavior ID
+	Target    string  // Target behavior ID
+	Kind      string  // Edge kind (e.g., "co-activated")
+	NewWeight float64 // Updated weight value
+}
+
 // Direction specifies edge traversal direction.
 type Direction string
 


### PR DESCRIPTION
## Summary

- Implements **Tier 3** of the feedback loop plan: when behaviors are frequently co-activated (injected together by `floop_active`), edges between them strengthen using **Oja's self-limiting Hebbian rule**
- Oja's rule (`dW = η·(A_i·A_j - A_j²·W)`) prevents unbounded weight growth that naive Hebbian learning causes in spreading activation networks — weight norms converge naturally
- New `"co-activated"` edge kind with creation gate (3 co-occurrences in 7 days), weight bounds `[0.01, 0.95]`, and weak edge pruning

## Key Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Edge type | New `"co-activated"` kind | Clean separation from semantic edges; never modifies requires/overrides/conflicts/similar-to/learned-from |
| Store changes | Duck-typed `EdgeWeightUpdater` sub-interface | Follows existing `edgeToucher` pattern; non-breaking |
| Trigger | Separate `runBackground("hebbian-update")` | Isolates from other background tasks; droppable under load |
| Pair selection | Activation threshold ≥ 0.3, exclude seed-seed pairs | Aligned with sigmoid inflection; seed co-activation reflects context matching, not behavioral affinity |
| Creation gate | 3 co-occurrences in 7 days | Prevents ephemeral co-activations from polluting graph |
| Learning rate | η = 0.05, no decay | Oja self-limits; fixed η allows adaptation to changing patterns |
| Weight bounds | [0.01, 0.95] | Floor triggers pruning; ceiling prevents dominating semantic edges |

## Files Changed

**New:**
- `internal/spreading/hebbian.go` — `OjaUpdate()`, `ExtractCoActivationPairs()`, `HebbianConfig`
- `internal/spreading/hebbian_test.go` — convergence, self-limiting, anti-ant-mill, pair extraction tests
- `internal/mcp/hebbian.go` — `coActivationTracker`, `applyHebbianUpdates()`
- `internal/mcp/hebbian_test.go` — creation gate, window expiry, different pairs tests

**Modified:**
- `internal/store/store.go` — `EdgeWeightUpdate` type
- `internal/store/sqlite.go` — `BatchUpdateEdgeWeights()`, `PruneWeakEdges()`
- `internal/store/multi.go` — delegation for new batch methods
- `internal/store/sqlite_test.go` — batch update + prune tests
- `internal/mcp/server.go` — `coActivationTracker` + `hebbianConfig` fields
- `internal/mcp/handlers.go` — `hebbian-update` background goroutine in `handleFloopActive`

## Test plan

- [x] Oja convergence: 1000+ iterations with constant activation, weight stabilizes
- [x] Anti-ant-mill: triangle stability test (3 behaviors, equal activation, no edge dominates)
- [x] Self-limiting: weight does not exceed MaxWeight
- [x] Asymmetric activation: weight converges to A_i/A_j ratio
- [x] Weakening: forgetting term dominates when weight exceeds equilibrium
- [x] Pair extraction: canonical ordering, seed-seed exclusion, threshold filtering
- [x] Creation gate: 3 co-occurrences required, window expiry
- [x] Store: batch weight update, prune by threshold, kind isolation
- [x] All 27 packages pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)