### PR TITLE
fix: initialize edge weight and timestamp in learning pipeline

### DIFF
--- a/internal/learning/loop.go
+++ b/internal/learning/loop.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/dedup"
@@ -381,9 +382,11 @@ func (l *learningLoop) commitBehavior(ctx context.Context, behavior *models.Beha
 	// Add edges
 	for _, e := range placement.ProposedEdges {
 		edge := store.Edge{
-			Source: e.From,
-			Target: e.To,
-			Kind:   e.Kind,
+			Source:    e.From,
+			Target:    e.To,
+			Kind:      e.Kind,
+			Weight:    1.0,
+			CreatedAt: time.Now(),
 		}
 		if err := l.store.AddEdge(ctx, edge); err != nil {
 			return scope, err


### PR DESCRIPTION
## Summary
- ProposedEdge → store.Edge conversion in `learning/loop.go` was missing `Weight` and `CreatedAt` fields
- This produced zero-value edges (weight=0, created_at=0001-01-01) that dilute spreading activation by inflating outDegree denominators
- Sets `Weight: 1.0` and `CreatedAt: time.Now()` for all edges created from ProposedEdges

## Test plan
- [x] New test verifies edges from ProcessCorrection have Weight > 0 and non-zero CreatedAt
- [x] All existing learning tests pass
- [x] `go test ./internal/learning/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)