### PR TITLE
fix: prevent override edges from scoped to unscoped behaviors

### DIFF
--- a/docs/SCIENCE.md
+++ b/docs/SCIENCE.md
@@ -119,6 +119,12 @@ Co-activated edges aren't created on the first co-occurrence. Instead, floop tra
 
 Seed-to-seed pairs are excluded: if both behaviors activated because they matched the same context predicates (both are seeds), their co-occurrence reflects context matching, not genuine affinity.
 
+### Override Edge Semantics
+
+When the learning pipeline places a new behavior, it evaluates `isMoreSpecific(a, b)` to determine whether one behavior's `when` conditions are a strict superset of another's. If so, it creates an `overrides` edge from the more-specific behavior to the less-specific one.
+
+Behaviors with empty `when` maps (`{}`) are treated as **unscoped** — they apply everywhere and are not considered "less specific" than scoped behaviors. This means no override edges are created from scoped behaviors to unscoped ones. Without this distinction, every scoped behavior would override every unscoped one, producing O(n*m) spurious edges that inflate outDegree denominators and dilute spreading activation.
+
 ## Related Work
 
 - **HippoRAG** ([github.com/OSU-NLP-Group/HippoRAG](https://github.com/OSU-NLP-Group/HippoRAG)) — Episodic memory organization for LLMs inspired by hippocampal indexing

--- a/internal/learning/place.go
+++ b/internal/learning/place.go
@@ -422,6 +422,12 @@ func (p *graphPlacer) isMoreSpecific(a, b map[string]interface{}) bool {
 		return false
 	}
 
+	// Empty when means "unscoped" (applies everywhere), not "less specific".
+	// A scoped behavior is not a specialization of an unscoped one.
+	if len(b) == 0 {
+		return false
+	}
+
 	for key, valueB := range b {
 		valueA, exists := a[key]
 		if !exists {

--- a/internal/learning/place_test.go
+++ b/internal/learning/place_test.go
@@ -374,12 +374,12 @@ func TestGraphPlacer_isMoreSpecific(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "empty b",
+			name: "empty b (unscoped, not less specific)",
 			a: map[string]interface{}{
 				"language": "go",
 			},
 			b:    map[string]interface{}{},
-			want: true,
+			want: false,
 		},
 		{
 			name: "both empty",
@@ -396,6 +396,21 @@ func TestGraphPlacer_isMoreSpecific(t *testing.T) {
 				t.Errorf("isMoreSpecific() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestIsMoreSpecific_EmptyWhen(t *testing.T) {
+	s := store.NewInMemoryGraphStore()
+	placer := NewGraphPlacer(s).(*graphPlacer)
+
+	// A scoped behavior should NOT be considered "more specific" than
+	// an unscoped behavior. Empty when means "unscoped", not "less specific".
+	got := placer.isMoreSpecific(
+		map[string]interface{}{"task": "dev"},
+		map[string]interface{}{},
+	)
+	if got {
+		t.Errorf("isMoreSpecific({task:dev}, {}) = true, want false; empty when is unscoped, not less specific")
 	}
 }
 


### PR DESCRIPTION
## Summary
- `isMoreSpecific()` treated empty `when` maps as "less specific" than any scoped behavior
- This created O(n*m) spurious override edges (2362 in local store)
- Empty `when` means "unscoped" — not a less-specific version of scoped behaviors
- Added guard: `if len(b) == 0 { return false }`

## Test plan
- [x] New test verifies `isMoreSpecific({task:dev}, {})` returns false
- [x] All existing placement tests pass
- [x] `go test ./internal/learning/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)