### PR TITLE
fix: remove writeScope, route behaviors by scope classification

### DIFF
--- a/cmd/floop/cmd_activate.go
+++ b/cmd/floop/cmd_activate.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/nvandessel/feedback-loop/internal/activation"
 	"github.com/nvandessel/feedback-loop/internal/config"
-	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/learning"
 	"github.com/nvandessel/feedback-loop/internal/models"
 	"github.com/nvandessel/feedback-loop/internal/session"
@@ -83,7 +82,7 @@ func runActivate(cmd *cobra.Command, args []string) error {
 	actCtx := ctxBuilder.Build()
 
 	// Open store (both local and global)
-	graphStore, err := store.NewMultiGraphStore(root, constants.ScopeLocal)
+	graphStore, err := store.NewMultiGraphStore(root)
 	if err != nil {
 		return fmt.Errorf("opening store: %w", err)
 	}

--- a/cmd/floop/cmd_backup.go
+++ b/cmd/floop/cmd_backup.go
@@ -63,7 +63,7 @@ Examples:
 			}
 
 			ctx := context.Background()
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeBoth)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open store: %w", err)
 			}
@@ -186,7 +186,7 @@ Examples:
 			}
 
 			ctx := context.Background()
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeBoth)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open store: %w", err)
 			}

--- a/cmd/floop/cmd_connect.go
+++ b/cmd/floop/cmd_connect.go
@@ -74,7 +74,7 @@ Examples:
 			}
 
 			ctx := context.Background()
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeBoth)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open store: %w", err)
 			}

--- a/cmd/floop/cmd_curation.go
+++ b/cmd/floop/cmd_curation.go
@@ -41,7 +41,7 @@ Use 'floop restore' to undo this action.`,
 			}
 
 			// Open graph store
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeLocal)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open graph store: %w", err)
 			}
@@ -171,7 +171,7 @@ Use --replacement to link to a newer behavior.`,
 			}
 
 			// Open graph store
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeLocal)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open graph store: %w", err)
 			}
@@ -314,7 +314,7 @@ This undoes 'floop forget' or 'floop deprecate'.`,
 			}
 
 			// Open graph store
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeLocal)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open graph store: %w", err)
 			}
@@ -455,7 +455,7 @@ This action cannot be undone with restore.`,
 			}
 
 			// Open graph store
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeLocal)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open graph store: %w", err)
 			}

--- a/cmd/floop/cmd_detect.go
+++ b/cmd/floop/cmd_detect.go
@@ -173,7 +173,7 @@ Examples:
 			}
 
 			// Open graph store
-			graphStore, err := store.NewMultiGraphStore(root, store.ScopeLocal)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				if jsonOut {
 					json.NewEncoder(os.Stdout).Encode(map[string]interface{}{

--- a/cmd/floop/cmd_graph.go
+++ b/cmd/floop/cmd_graph.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/ranking"
 	"github.com/nvandessel/feedback-loop/internal/store"
 	"github.com/nvandessel/feedback-loop/internal/visualization"
@@ -104,7 +103,7 @@ func newGraphCmd() *cobra.Command {
 
 // openStoreForGraph opens a multi-store for graph visualization.
 func openStoreForGraph(projectRoot string) (store.GraphStore, error) {
-	gs, err := store.NewMultiGraphStore(projectRoot, constants.ScopeLocal)
+	gs, err := store.NewMultiGraphStore(projectRoot)
 	if err != nil {
 		return nil, fmt.Errorf("open multi-store: %w", err)
 	}

--- a/cmd/floop/cmd_learn_test.go
+++ b/cmd/floop/cmd_learn_test.go
@@ -293,7 +293,8 @@ func TestReprocessCmdSanitizesCorrections(t *testing.T) {
 
 			// Verify the behavior stored in the graph has sanitized content.
 			// The correction itself is also rewritten with sanitized values.
-			graphStore, err := store.NewFileGraphStore(tmpDir)
+			// Use MultiGraphStore since behaviors may route to global based on scope classification.
+			graphStore, err := store.NewMultiGraphStore(tmpDir)
 			if err != nil {
 				t.Fatalf("failed to open store: %v", err)
 			}

--- a/cmd/floop/cmd_list.go
+++ b/cmd/floop/cmd_list.go
@@ -254,7 +254,7 @@ func loadBehaviorsWithScope(projectRoot string, scope constants.Scope) ([]models
 
 	case constants.ScopeBoth:
 		// Load from both stores using MultiGraphStore
-		graphStore, err = store.NewMultiGraphStore(projectRoot, constants.ScopeLocal)
+		graphStore, err = store.NewMultiGraphStore(projectRoot)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open multi-store: %w", err)
 		}

--- a/cmd/floop/cmd_tags.go
+++ b/cmd/floop/cmd_tags.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/learning"
 	"github.com/nvandessel/feedback-loop/internal/store"
 	"github.com/nvandessel/feedback-loop/internal/tagging"
@@ -37,14 +36,7 @@ Use --dry-run to preview changes without modifying the store.`,
 			root, _ := cmd.Flags().GetString("root")
 			dryRun, _ := cmd.Flags().GetBool("dry-run")
 			jsonOut, _ := cmd.Flags().GetBool("json")
-			scope, _ := cmd.Flags().GetString("scope")
-
-			storeScope := constants.Scope(scope)
-			if !storeScope.Valid() {
-				storeScope = constants.ScopeBoth
-			}
-
-			graphStore, err := store.NewMultiGraphStore(root, storeScope)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("opening graph store: %w", err)
 			}

--- a/cmd/floop/cmd_validate.go
+++ b/cmd/floop/cmd_validate.go
@@ -106,7 +106,7 @@ func runSingleStoreValidation(ctx context.Context, root string, scope store.Stor
 
 // runMultiStoreValidation validates both local and global stores.
 func runMultiStoreValidation(ctx context.Context, root string, jsonOut bool) error {
-	multiStore, err := store.NewMultiGraphStore(root, store.ScopeBoth)
+	multiStore, err := store.NewMultiGraphStore(root)
 	if err != nil {
 		return fmt.Errorf("failed to open stores: %w", err)
 	}

--- a/cmd/floop/main_test.go
+++ b/cmd/floop/main_test.go
@@ -508,8 +508,8 @@ func TestCurationWorkflow(t *testing.T) {
 		t.Fatalf("learn failed: %v", err)
 	}
 
-	// Get behavior ID from store
-	graphStore, err := store.NewFileGraphStore(tmpDir)
+	// Get behavior ID from store (use MultiGraphStore since behaviors may route to global)
+	graphStore, err := store.NewMultiGraphStore(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to open store: %v", err)
 	}
@@ -539,7 +539,7 @@ func TestCurationWorkflow(t *testing.T) {
 	}
 
 	// Verify node kind changed
-	graphStore, _ = store.NewFileGraphStore(tmpDir)
+	graphStore, _ = store.NewMultiGraphStore(tmpDir)
 	node, _ := graphStore.GetNode(ctx, behaviorID)
 	if node.Kind != "forgotten-behavior" {
 		t.Errorf("after forget, kind = %q, want 'forgotten-behavior'", node.Kind)
@@ -562,7 +562,7 @@ func TestCurationWorkflow(t *testing.T) {
 	}
 
 	// Verify restored
-	graphStore, _ = store.NewFileGraphStore(tmpDir)
+	graphStore, _ = store.NewMultiGraphStore(tmpDir)
 	node, _ = graphStore.GetNode(ctx, behaviorID)
 	if node.Kind != "behavior" {
 		t.Errorf("after restore, kind = %q, want 'behavior'", node.Kind)
@@ -586,7 +586,7 @@ func TestCurationWorkflow(t *testing.T) {
 	}
 
 	// Verify deprecated
-	graphStore, _ = store.NewFileGraphStore(tmpDir)
+	graphStore, _ = store.NewMultiGraphStore(tmpDir)
 	node, _ = graphStore.GetNode(ctx, behaviorID)
 	if node.Kind != "deprecated-behavior" {
 		t.Errorf("after deprecate, kind = %q, want 'deprecated-behavior'", node.Kind)
@@ -609,7 +609,7 @@ func TestCurationWorkflow(t *testing.T) {
 	}
 
 	// Verify restored again
-	graphStore, _ = store.NewFileGraphStore(tmpDir)
+	graphStore, _ = store.NewMultiGraphStore(tmpDir)
 	node, _ = graphStore.GetNode(ctx, behaviorID)
 	if node.Kind != "behavior" {
 		t.Errorf("after second restore, kind = %q, want 'behavior'", node.Kind)
@@ -660,9 +660,9 @@ func TestMergeWorkflow(t *testing.T) {
 		t.Fatalf("learn 2 failed: %v", err)
 	}
 
-	// Get behavior IDs from store
+	// Get behavior IDs from store (use MultiGraphStore since behaviors may route to global)
 	ctx := context.Background()
-	graphStore, err := store.NewFileGraphStore(tmpDir)
+	graphStore, err := store.NewMultiGraphStore(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to open store: %v", err)
 	}
@@ -691,7 +691,7 @@ func TestMergeWorkflow(t *testing.T) {
 	}
 
 	// Verify source is now merged-behavior
-	graphStore, _ = store.NewFileGraphStore(tmpDir)
+	graphStore, _ = store.NewMultiGraphStore(tmpDir)
 	sourceNode, _ := graphStore.GetNode(ctx, id1)
 	if sourceNode.Kind != "merged-behavior" {
 		t.Errorf("source kind = %q, want 'merged-behavior'", sourceNode.Kind)
@@ -802,9 +802,9 @@ func TestRestoreActiveBehaviorFails(t *testing.T) {
 		t.Fatalf("learn failed: %v", err)
 	}
 
-	// Get behavior ID from store
+	// Get behavior ID from store (use MultiGraphStore since behaviors may route to global)
 	ctx := context.Background()
-	graphStore, err := store.NewFileGraphStore(tmpDir)
+	graphStore, err := store.NewMultiGraphStore(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to open store: %v", err)
 	}
@@ -878,9 +878,9 @@ func TestDeprecateWithReplacement(t *testing.T) {
 		t.Fatalf("learn 2 failed: %v", err)
 	}
 
-	// Get behavior IDs from store
+	// Get behavior IDs from store (use MultiGraphStore since behaviors may route to global)
 	ctx := context.Background()
-	graphStore, err := store.NewFileGraphStore(tmpDir)
+	graphStore, err := store.NewMultiGraphStore(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to open store: %v", err)
 	}
@@ -910,7 +910,7 @@ func TestDeprecateWithReplacement(t *testing.T) {
 	}
 
 	// Verify deprecated-to edge exists with valid Weight and CreatedAt
-	graphStore, err = store.NewFileGraphStore(tmpDir)
+	graphStore, err = store.NewMultiGraphStore(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to reopen store: %v", err)
 	}

--- a/cmd/floop/stats.go
+++ b/cmd/floop/stats.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"sort"
 
-	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/learning"
 	"github.com/nvandessel/feedback-loop/internal/models"
 	"github.com/nvandessel/feedback-loop/internal/store"
@@ -34,17 +33,10 @@ Examples:
 			jsonOut, _ := cmd.Flags().GetBool("json")
 			topN, _ := cmd.Flags().GetInt("top")
 			sortBy, _ := cmd.Flags().GetString("sort")
-			scope, _ := cmd.Flags().GetString("scope")
 			budget, _ := cmd.Flags().GetInt("budget")
 
-			// Parse scope
-			storeScope := constants.Scope(scope)
-			if !storeScope.Valid() {
-				storeScope = constants.ScopeLocal
-			}
-
 			// Open graph store
-			graphStore, err := store.NewMultiGraphStore(root, storeScope)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open graph store: %w", err)
 			}

--- a/cmd/floop/summarize.go
+++ b/cmd/floop/summarize.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/nvandessel/feedback-loop/internal/constants"
 	"github.com/nvandessel/feedback-loop/internal/learning"
 	"github.com/nvandessel/feedback-loop/internal/store"
 	"github.com/nvandessel/feedback-loop/internal/summarization"
@@ -32,21 +31,14 @@ Examples:
 			jsonOut, _ := cmd.Flags().GetBool("json")
 			allBehaviors, _ := cmd.Flags().GetBool("all")
 			missingOnly, _ := cmd.Flags().GetBool("missing")
-			scope, _ := cmd.Flags().GetString("scope")
 
 			// Validate flags
 			if len(args) == 0 && !allBehaviors && !missingOnly {
 				return fmt.Errorf("specify a behavior ID or use --all/--missing")
 			}
 
-			// Parse scope
-			storeScope := constants.Scope(scope)
-			if !storeScope.Valid() {
-				storeScope = constants.ScopeLocal
-			}
-
 			// Open graph store
-			graphStore, err := store.NewMultiGraphStore(root, storeScope)
+			graphStore, err := store.NewMultiGraphStore(root)
 			if err != nil {
 				return fmt.Errorf("failed to open graph store: %w", err)
 			}
@@ -135,7 +127,6 @@ Examples:
 
 	cmd.Flags().Bool("all", false, "Generate summaries for all behaviors")
 	cmd.Flags().Bool("missing", false, "Only generate for behaviors without summaries")
-	cmd.Flags().String("scope", "local", "Scope: local, global, or both")
 
 	return cmd
 }

--- a/docs/FLOOP_USAGE.md
+++ b/docs/FLOOP_USAGE.md
@@ -92,11 +92,12 @@ floop learn \
 # With auto-merge to consolidate similar behaviors
 floop learn --wrong "..." --right "..." --auto-merge
 
-# Specify scope (local or global)
+# Override auto-classification (default: auto-classify based on When conditions)
 floop learn --wrong "..." --right "..." --scope local
+floop learn --wrong "..." --right "..." --scope global
 
-# Note: Via MCP, scope is automatically classified based on the behavior's
-# activation conditions. The --scope flag is only needed for CLI usage.
+# Note: Scope is automatically classified based on the behavior's activation
+# conditions. The --scope flag overrides auto-classification when set.
 ```
 
 ### Querying Behaviors

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -154,12 +154,12 @@ Capture a correction and extract a reusable behavior.
 
 **Scope Classification:**
 
-The `scope` field indicates where the behavior was stored. The MCP server automatically classifies behaviors based on their activation conditions:
+The `scope` field indicates where the behavior was stored. Behaviors are automatically routed to the correct store based on their activation conditions:
 
 - **`"local"`** — Behavior has project-specific conditions (`file_path` or `environment` in its When predicate). Stored in `./.floop/` only.
 - **`"global"`** — Behavior has universal conditions (language-only, task-only, or no conditions). Stored in `~/.floop/` only.
 
-This prevents duplication across stores. Providing a `file` parameter with a directory path (e.g., `"internal/store/file.go"`) typically produces a local behavior, while omitting `file` or providing a bare filename produces a global one.
+Each behavior goes to exactly one store — no duplication. Providing a `file` parameter with a directory path (e.g., `"internal/store/file.go"`) typically produces a local behavior, while omitting `file` or providing a bare filename produces a global one.
 
 ---
 

--- a/internal/constants/scope.go
+++ b/internal/constants/scope.go
@@ -10,7 +10,9 @@ const (
 	// ScopeGlobal indicates the behavior applies across all projects
 	ScopeGlobal Scope = "global"
 
-	// ScopeBoth indicates the operation should consider both scopes
+	// ScopeBoth indicates the operation should consider both scopes.
+	// Used for read/query operations (dedup --scope both, validate --scope both).
+	// Not a valid write scope — each behavior belongs to exactly one store.
 	ScopeBoth Scope = "both"
 )
 

--- a/internal/learning/scope.go
+++ b/internal/learning/scope.go
@@ -5,21 +5,9 @@ import (
 	"github.com/nvandessel/feedback-loop/internal/models"
 )
 
-// localScopeKeys are When condition keys that indicate project-specific behaviors.
-// file_path implies project directory structure; environment implies deployment config.
-var localScopeKeys = []string{"file_path", "environment"}
-
-// ClassifyScope determines whether a behavior should be stored locally or globally
-// based on its When conditions. Behaviors with project-specific conditions (file_path
-// or environment) are local; everything else (language-only, task-only, empty) is global.
+// ClassifyScope determines whether a behavior should be stored locally or globally.
+// Delegates to models.ClassifyScope; kept here for backward compatibility with
+// existing callers in the learning package.
 func ClassifyScope(behavior *models.Behavior) constants.Scope {
-	if behavior.When == nil {
-		return constants.ScopeGlobal
-	}
-	for _, key := range localScopeKeys {
-		if _, ok := behavior.When[key]; ok {
-			return constants.ScopeLocal
-		}
-	}
-	return constants.ScopeGlobal
+	return models.ClassifyScope(behavior)
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -77,7 +77,7 @@ type Config struct {
 // NewServer creates a new MCP server with floop tools.
 func NewServer(cfg *Config) (*Server, error) {
 	// Create multi-graph store (local + global)
-	graphStore, err := store.NewMultiGraphStore(cfg.Root, store.ScopeBoth)
+	graphStore, err := store.NewMultiGraphStore(cfg.Root)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create graph store: %w", err)
 	}

--- a/internal/models/scope.go
+++ b/internal/models/scope.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"github.com/nvandessel/feedback-loop/internal/constants"
+)
+
+// localScopeKeys are When condition keys that indicate project-specific behaviors.
+// file_path implies project directory structure; environment implies deployment config.
+var localScopeKeys = []string{"file_path", "environment"}
+
+// ClassifyScope determines whether a behavior should be stored locally or globally
+// based on its When conditions. Behaviors with project-specific conditions (file_path
+// or environment) are local; everything else (language-only, task-only, empty) is global.
+func ClassifyScope(behavior *Behavior) constants.Scope {
+	if behavior.When == nil {
+		return constants.ScopeGlobal
+	}
+	for _, key := range localScopeKeys {
+		if _, ok := behavior.When[key]; ok {
+			return constants.ScopeLocal
+		}
+	}
+	return constants.ScopeGlobal
+}

--- a/internal/models/scope_test.go
+++ b/internal/models/scope_test.go
@@ -1,0 +1,99 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/nvandessel/feedback-loop/internal/constants"
+)
+
+func TestClassifyScope(t *testing.T) {
+	tests := []struct {
+		name string
+		when map[string]interface{}
+		want constants.Scope
+	}{
+		{
+			name: "nil When defaults to global",
+			when: nil,
+			want: constants.ScopeGlobal,
+		},
+		{
+			name: "empty When defaults to global",
+			when: map[string]interface{}{},
+			want: constants.ScopeGlobal,
+		},
+		{
+			name: "language only is global",
+			when: map[string]interface{}{
+				"language": "go",
+			},
+			want: constants.ScopeGlobal,
+		},
+		{
+			name: "task only is global",
+			when: map[string]interface{}{
+				"task": "testing",
+			},
+			want: constants.ScopeGlobal,
+		},
+		{
+			name: "language and task is global",
+			when: map[string]interface{}{
+				"language": "python",
+				"task":     "refactoring",
+			},
+			want: constants.ScopeGlobal,
+		},
+		{
+			name: "file_path present is local",
+			when: map[string]interface{}{
+				"file_path": "internal/store/**",
+			},
+			want: constants.ScopeLocal,
+		},
+		{
+			name: "file_path with language is local",
+			when: map[string]interface{}{
+				"language":  "go",
+				"file_path": "cmd/floop/**",
+			},
+			want: constants.ScopeLocal,
+		},
+		{
+			name: "environment present is local",
+			when: map[string]interface{}{
+				"environment": "production",
+			},
+			want: constants.ScopeLocal,
+		},
+		{
+			name: "environment with other keys is local",
+			when: map[string]interface{}{
+				"language":    "python",
+				"task":        "deployment",
+				"environment": "staging",
+			},
+			want: constants.ScopeLocal,
+		},
+		{
+			name: "both file_path and environment is local",
+			when: map[string]interface{}{
+				"file_path":   "src/**",
+				"environment": "dev",
+			},
+			want: constants.ScopeLocal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			behavior := &Behavior{
+				When: tt.when,
+			}
+			got := ClassifyScope(behavior)
+			if got != tt.want {
+				t.Errorf("ClassifyScope() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/store/export.go
+++ b/internal/store/export.go
@@ -43,7 +43,7 @@ func (s *SQLiteGraphStore) ImportNodesFromJSONL(ctx context.Context, path string
 		}
 
 		// Add the node (uses INSERT OR REPLACE)
-		if node.Kind == "behavior" || node.Kind == "forgotten-behavior" {
+		if isBehaviorKind(node.Kind) {
 			if _, err := s.addBehavior(ctx, node); err != nil {
 				return fmt.Errorf("failed to import node %s: %w", node.ID, err)
 			}


### PR DESCRIPTION
## Summary

- **Remove `writeScope` from `MultiGraphStore`** — `ScopeBoth` was causing `AddNode` to write to both local and global stores, producing duplicate behaviors (141 duplicates observed)
- **`AddNode` defaults to global**, `AddNodeToScope` routes directly to the requested scope and rejects `ScopeBoth` as a write target
- **Move `ClassifyScope` to `models` package** to break import cycle between `learning` and `dedup`, with thin wrapper in `learning` for backward compatibility
- **Add `ScopeOverride` to `LearningLoopConfig`** so CLI `--scope` flag overrides auto-classification without touching store creation
- **Make dedup writes scope-aware** via `AddNodeToScope` + `ClassifyScope`
- **Fix `ImportNodesFromJSONL`** to use `isBehaviorKind()` instead of hardcoded kind list — deprecated and merged behaviors were being imported as generic nodes, losing metadata

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all 27 packages pass
- [x] `gofmt` — no formatting issues
- [x] New tests: `models.ClassifyScope`, `LearningLoop_ScopeOverride`, `AddNode_DefaultsToGlobal`, `AddNodeToScope_RejectsInvalidScope`
- [x] Integration tests updated to use `MultiGraphStore` for behavior lookups (behaviors may route to global store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)