### PR TITLE
test: add seed selection, inhibition, and creation gate sim tests

### DIFF
--- a/internal/simulation/gate_default_test.go
+++ b/internal/simulation/gate_default_test.go
@@ -1,0 +1,161 @@
+package simulation_test
+
+import (
+	"testing"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+	"github.com/nvandessel/feedback-loop/internal/simulation"
+	"github.com/nvandessel/feedback-loop/internal/spreading"
+)
+
+// TestCreationGateDefault validates that edges are NOT created until the
+// creation gate threshold (default=3) is met. This exercises the co-activation
+// counting logic in Runner.applyHebbian.
+//
+// Setup:
+//   - 4 behaviors: hub (seed), freq-b, freq-c, rare-d
+//   - Hub has semantic edges to all three non-seeds (weight 0.9)
+//   - Hub is seeded every session; rare-d is additionally seeded only in
+//     sessions 0, 5, and 10 (to test slow gate accumulation)
+//   - HebbianConfig with default CreationGate=3 (NOT gate=1)
+//   - CreateEdges=true, 10 sessions
+//   - Boosted spread config so non-seeds reach above activation threshold
+//
+// Expected:
+//   - After session 0: no co-activated edge between freq-b and freq-c (count=1)
+//   - After session 1: no co-activated edge (count=2)
+//   - After session 2: edge freq-b↔freq-c IS created (count=3, gate met)
+//   - After session 9: edge has been strengthened via Oja
+//   - No weight explosion
+func TestCreationGateDefault(t *testing.T) {
+	r := simulation.NewRunner(t)
+
+	behaviors := []simulation.BehaviorSpec{
+		{ID: "hub", Name: "Hub Seed", Kind: models.BehaviorKindDirective, Canonical: "Central hub behavior"},
+		{ID: "freq-b", Name: "Frequent B", Kind: models.BehaviorKindDirective, Canonical: "Frequently co-activated B"},
+		{ID: "freq-c", Name: "Frequent C", Kind: models.BehaviorKindDirective, Canonical: "Frequently co-activated C"},
+		{ID: "rare-d", Name: "Rare D", Kind: models.BehaviorKindDirective, Canonical: "Rarely co-activated D"},
+	}
+
+	// Strong semantic edges from hub to all non-seeds.
+	edges := []simulation.EdgeSpec{
+		{Source: "hub", Target: "freq-b", Kind: "semantic", Weight: 0.9},
+		{Source: "hub", Target: "freq-c", Kind: "semantic", Weight: 0.9},
+		{Source: "hub", Target: "rare-d", Kind: "semantic", Weight: 0.9},
+	}
+
+	// Boosted spread config: with 3 outbound edges from hub, we need strong
+	// propagation so non-seeds pass the co-activation threshold.
+	// energy = 0.8 * 0.95 * 0.9 / 3 * 0.85 = 0.1938, sigmoid(0.1938) ≈ 0.256
+	spreadCfg := spreading.Config{
+		MaxSteps:          3,
+		DecayFactor:       0.85,
+		SpreadFactor:      0.95,
+		MinActivation:     0.01,
+		TemporalDecayRate: 0.001,
+	}
+
+	// Default Hebbian config: CreationGate=3.
+	hebbianCfg := spreading.DefaultHebbianConfig()
+	hebbianCfg.ActivationThreshold = 0.1 // Non-seeds reach ~0.26 post-sigmoid
+
+	sessions := make([]simulation.SessionContext, 10)
+
+	scenario := simulation.Scenario{
+		Name:           "creation-gate-default",
+		Behaviors:      behaviors,
+		Edges:          edges,
+		Sessions:       sessions,
+		SpreadConfig:   &spreadCfg,
+		HebbianConfig:  &hebbianCfg,
+		HebbianEnabled: true,
+		CreateEdges:    true,
+		SeedOverride: func(sessionIndex int) []spreading.Seed {
+			seeds := []spreading.Seed{
+				{BehaviorID: "hub", Activation: 0.8, Source: "test"},
+			}
+			// Rare-d additionally seeded only in sessions 0, 5 to boost
+			// its activation (otherwise it gets spreading activation from hub).
+			if sessionIndex == 0 || sessionIndex == 5 {
+				seeds = append(seeds, spreading.Seed{
+					BehaviorID: "rare-d",
+					Activation: 0.6,
+					Source:     "test",
+				})
+			}
+			return seeds
+		},
+	}
+
+	result := r.Run(scenario)
+
+	// Log first few sessions for debugging.
+	for i := 0; i < 5 && i < len(result.Sessions); i++ {
+		sr := result.Sessions[i]
+		t.Logf("Session %d: pairs=%d results=%d", sr.Index, len(sr.Pairs), len(sr.Results))
+		for _, p := range sr.Pairs {
+			t.Logf("  pair: %s <-> %s (%.4f, %.4f)", p.BehaviorA, p.BehaviorB, p.ActivationA, p.ActivationB)
+		}
+	}
+
+	// --- Assertion 1: Edge absent after sessions 0 and 1 (gate count < 3) ---
+	simulation.AssertEdgeAbsentAtSession(t, result, "freq-b", "freq-c", 0)
+	simulation.AssertEdgeAbsentAtSession(t, result, "freq-b", "freq-c", 1)
+
+	// --- Assertion 2: Edge present after session 2 (gate count = 3) ---
+	simulation.AssertEdgePresentAtSession(t, result, "freq-b", "freq-c", 2)
+
+	// --- Assertion 3: Edge strengthened by session 9 vs session 2 ---
+	// Once created, Oja should strengthen the edge over subsequent sessions.
+	getEdgeWeight := func(sessionIdx int, a, b string) float64 {
+		sr := result.Sessions[sessionIdx]
+		keyAB := simulation.EdgeKey(a, b, "co-activated")
+		keyBA := simulation.EdgeKey(b, a, "co-activated")
+		if w, ok := sr.EdgeWeights[keyAB]; ok {
+			return w
+		}
+		if w, ok := sr.EdgeWeights[keyBA]; ok {
+			return w
+		}
+		return -1
+	}
+
+	weightAtCreation := getEdgeWeight(2, "freq-b", "freq-c")
+	weightAtEnd := getEdgeWeight(len(result.Sessions)-1, "freq-b", "freq-c")
+
+	t.Logf("freq-b↔freq-c weight at creation (session 2): %.6f", weightAtCreation)
+	t.Logf("freq-b↔freq-c weight at end (session %d): %.6f", len(result.Sessions)-1, weightAtEnd)
+
+	if weightAtCreation >= 0 && weightAtEnd >= 0 {
+		if weightAtEnd <= weightAtCreation {
+			t.Errorf("expected edge weight to increase via Oja: creation=%.6f, end=%.6f", weightAtCreation, weightAtEnd)
+		}
+	}
+
+	// --- Assertion 4: Verify co-activation counter state ---
+	// freq-b:freq-c should have been counted 3+ times (once per session they co-activate).
+	counts := r.CoActivationCounts()
+	bcKey := simulation.CoActivationKeyFor("freq-b", "freq-c")
+	t.Logf("Co-activation counts: %v", counts)
+	if count, ok := counts[bcKey]; ok {
+		// Counter should show 3 (the gate was met at 3, then subsequent
+		// co-activations update existing edge instead of incrementing counter).
+		if count < 3 {
+			t.Errorf("expected co-activation count for freq-b:freq-c >= 3, got %d", count)
+		}
+	} else {
+		t.Errorf("no co-activation count found for key %s", bcKey)
+	}
+
+	// --- Assertion 5: No weight explosion ---
+	simulation.AssertNoWeightExplosion(t, result, 0.95)
+
+	// --- Assertion 6: All sessions produce results ---
+	simulation.AssertResultsNotEmpty(t, result)
+
+	// Log final edge weights.
+	lastSession := result.Sessions[len(result.Sessions)-1]
+	for key, w := range lastSession.EdgeWeights {
+		t.Logf("Final edge: %s = %.6f", key, w)
+	}
+}

--- a/internal/simulation/inhibition_test.go
+++ b/internal/simulation/inhibition_test.go
@@ -1,0 +1,171 @@
+package simulation_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+	"github.com/nvandessel/feedback-loop/internal/simulation"
+	"github.com/nvandessel/feedback-loop/internal/spreading"
+)
+
+// TestLateralInhibitionIsolation validates that lateral inhibition creates
+// sharp winner/loser separation in a multi-session scenario using default
+// production config (Strength=0.15, Breadth=7).
+//
+// Setup:
+//   - 1 hub seed with 11 non-seed neighbors connected via semantic edges
+//   - 4 "strong" neighbors: semantic weight 0.9 (should become winners)
+//   - 3 "medium" neighbors: semantic weight 0.6 (2 winners, 1 loser at boundary)
+//   - 4 "weak" neighbors: semantic weight 0.2 (all losers, suppressed)
+//   - Default spread config with Inhibition enabled (Strength=0.15, Breadth=7)
+//   - HebbianEnabled=false to isolate inhibition dynamics
+//   - 10 sessions, same seed every time
+//
+// Key insight: Breadth=7 means 7 total winners INCLUDING hub. So 6 non-hub
+// nodes are winners (4 strong + 2 medium), and 5 are losers (1 medium + 4 weak).
+// Inhibition equalizes loser activations downward, creating a visible cliff
+// between the last winner and first loser.
+//
+// At default spread settings with 11 outbound edges, out-degree dilution
+// keeps post-sigmoid activations in a narrow range (~0.05-0.06). The test
+// validates relative ordering and the cliff property rather than absolute values.
+func TestLateralInhibitionIsolation(t *testing.T) {
+	r := simulation.NewRunner(t)
+
+	behaviors := []simulation.BehaviorSpec{
+		{ID: "hub", Name: "Hub Seed", Kind: models.BehaviorKindDirective, Canonical: "Central hub"},
+	}
+
+	strongIDs := []string{"strong-1", "strong-2", "strong-3", "strong-4"}
+	mediumIDs := []string{"medium-1", "medium-2", "medium-3"}
+	weakIDs := []string{"weak-1", "weak-2", "weak-3", "weak-4"}
+
+	for _, id := range strongIDs {
+		behaviors = append(behaviors, simulation.BehaviorSpec{
+			ID: id, Name: "Strong " + id, Kind: models.BehaviorKindDirective, Canonical: "Strong neighbor " + id,
+		})
+	}
+	for _, id := range mediumIDs {
+		behaviors = append(behaviors, simulation.BehaviorSpec{
+			ID: id, Name: "Medium " + id, Kind: models.BehaviorKindDirective, Canonical: "Medium neighbor " + id,
+		})
+	}
+	for _, id := range weakIDs {
+		behaviors = append(behaviors, simulation.BehaviorSpec{
+			ID: id, Name: "Weak " + id, Kind: models.BehaviorKindDirective, Canonical: "Weak neighbor " + id,
+		})
+	}
+
+	// Hub → all 11 neighbors via semantic edges with varying weights.
+	var edges []simulation.EdgeSpec
+	for _, id := range strongIDs {
+		edges = append(edges, simulation.EdgeSpec{Source: "hub", Target: id, Kind: "semantic", Weight: 0.9})
+	}
+	for _, id := range mediumIDs {
+		edges = append(edges, simulation.EdgeSpec{Source: "hub", Target: id, Kind: "semantic", Weight: 0.6})
+	}
+	for _, id := range weakIDs {
+		edges = append(edges, simulation.EdgeSpec{Source: "hub", Target: id, Kind: "semantic", Weight: 0.2})
+	}
+
+	sessions := make([]simulation.SessionContext, 10)
+
+	// Default spread config includes inhibition (Strength=0.15, Breadth=7).
+	spreadCfg := spreading.DefaultConfig()
+
+	scenario := simulation.Scenario{
+		Name:           "lateral-inhibition-isolation",
+		Behaviors:      behaviors,
+		Edges:          edges,
+		Sessions:       sessions,
+		SpreadConfig:   &spreadCfg,
+		HebbianEnabled: false,
+		SeedOverride: func(sessionIndex int) []spreading.Seed {
+			return []spreading.Seed{
+				{BehaviorID: "hub", Activation: 0.8, Source: "test"},
+			}
+		},
+	}
+
+	result := r.Run(scenario)
+
+	// Log session results for debugging.
+	for _, sr := range result.Sessions {
+		t.Logf("%s", simulation.FormatSessionDebug(sr))
+	}
+
+	// --- Assertion 1: Strong neighbors consistently outrank weak neighbors ---
+	for _, sr := range result.Sessions {
+		simulation.AssertInhibitionGap(t, sr, strongIDs, weakIDs, 0.005)
+	}
+
+	// --- Assertion 2: Cliff at the winner/loser boundary ---
+	// Breadth=7 includes hub, so 6 non-hub nodes are winners.
+	// The cliff should be between the 6th and 7th ranked non-hub behaviors.
+	lastSession := result.Sessions[len(result.Sessions)-1]
+	type rankedResult struct {
+		id         string
+		activation float64
+	}
+	var ranked []rankedResult
+	for _, res := range lastSession.Results {
+		if res.BehaviorID != "hub" {
+			ranked = append(ranked, rankedResult{id: res.BehaviorID, activation: res.Activation})
+		}
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		return ranked[i].activation > ranked[j].activation
+	})
+
+	t.Logf("Ranked activations (excluding hub):")
+	for i, r := range ranked {
+		t.Logf("  rank %d: %s = %.4f", i+1, r.id, r.activation)
+	}
+
+	// With Breadth=7 (hub + 6 non-hub winners), the cliff is between
+	// ranked[5] (last winner) and ranked[6] (first loser).
+	if len(ranked) >= 8 {
+		// Gap between adjacent winners (e.g., ranked[4] → ranked[5])
+		adjacentWinnerGap := ranked[4].activation - ranked[5].activation
+		// Gap at the cliff (ranked[5] → ranked[6])
+		cliffGap := ranked[5].activation - ranked[6].activation
+
+		t.Logf("Adjacent winner gap (rank 5→6): %.4f", adjacentWinnerGap)
+		t.Logf("Cliff gap (rank 6→7): %.4f", cliffGap)
+
+		if cliffGap <= adjacentWinnerGap {
+			t.Errorf("expected cliff gap (%.4f) > adjacent winner gap (%.4f) — inhibition should create a sharper boundary at rank 6→7",
+				cliffGap, adjacentWinnerGap)
+		}
+	}
+
+	// --- Assertion 3: Inhibition equalizes losers ---
+	// medium-3 (a natural "medium" that falls outside Breadth) should be
+	// suppressed to approximately the same level as weak nodes, demonstrating
+	// that inhibition pushes losers down regardless of their natural weight.
+	activationMap := make(map[string]float64)
+	for _, res := range lastSession.Results {
+		activationMap[res.BehaviorID] = res.Activation
+	}
+
+	// medium-1 and medium-2 should be at winner level (like each other)
+	// medium-3 should be at loser level (like weak nodes)
+	if actM1, ok1 := activationMap["medium-1"]; ok1 {
+		if actM3, ok3 := activationMap["medium-3"]; ok3 {
+			if actW1, okW := activationMap["weak-1"]; okW {
+				// medium-3 should be closer to weak-1 than to medium-1
+				distToWinner := actM1 - actM3
+				distToLoser := actM3 - actW1
+				t.Logf("medium-3 distance to winner (medium-1): %.4f, to loser (weak-1): %.4f", distToWinner, distToLoser)
+				if distToLoser > distToWinner {
+					t.Errorf("medium-3 (%.4f) closer to winners (%.4f) than losers (%.4f) — inhibition should push it to loser level",
+						actM3, actM1, actW1)
+				}
+			}
+		}
+	}
+
+	// --- Assertion 4: All sessions produce results ---
+	simulation.AssertResultsNotEmpty(t, result)
+}

--- a/internal/simulation/seed_selection_test.go
+++ b/internal/simulation/seed_selection_test.go
@@ -1,0 +1,216 @@
+package simulation_test
+
+import (
+	"testing"
+
+	"github.com/nvandessel/feedback-loop/internal/models"
+	"github.com/nvandessel/feedback-loop/internal/simulation"
+)
+
+// TestSeedSelectionIntegration exercises the real Pipeline.Run() path — no
+// SeedOverride. It validates that SeedSelector.SelectSeeds() correctly matches
+// behavior When conditions against ContextSnapshot fields, and that specificity
+// maps to the correct seed activation levels.
+//
+// Setup:
+//   - 6 behaviors with varying When conditions and specificity levels
+//   - 2 semantic edges to allow spreading from seeds to reachable neighbors
+//   - 6 sessions cycling through different ContextSnapshots
+//   - SeedOverride is nil — the scenario uses Pipeline.Run() (runner.go line 64-67)
+//
+// Expected:
+//   - Each context snapshot selects only the behaviors whose When conditions
+//     match the snapshot's fields
+//   - Higher specificity → higher seed activation (0.3 / 0.4 / 0.6)
+//   - always-lint (no When) appears in every session at activation 0.3
+//   - Language/task-specific behaviors only appear when context matches
+func TestSeedSelectionIntegration(t *testing.T) {
+	r := simulation.NewRunner(t)
+
+	behaviors := []simulation.BehaviorSpec{
+		{
+			ID: "go-security", Name: "Go Security", Kind: models.BehaviorKindDirective,
+			When:      map[string]interface{}{"language": "go", "task": "security"},
+			Canonical: "Security checks for Go code",
+		},
+		{
+			ID: "go-general", Name: "Go General", Kind: models.BehaviorKindDirective,
+			When:      map[string]interface{}{"language": "go"},
+			Canonical: "General Go practices",
+		},
+		{
+			ID: "python-style", Name: "Python Style", Kind: models.BehaviorKindDirective,
+			When:      map[string]interface{}{"language": "python"},
+			Canonical: "Python style guidelines",
+		},
+		{
+			ID: "ci-deploy", Name: "CI Deploy", Kind: models.BehaviorKindDirective,
+			When:      map[string]interface{}{"environment": "ci", "task": "deploy"},
+			Canonical: "CI deployment procedures",
+		},
+		{
+			ID: "always-lint", Name: "Always Lint", Kind: models.BehaviorKindDirective,
+			// When: nil — always-active, specificity=0 → activation 0.3
+			Canonical: "Always run linter",
+		},
+		{
+			ID: "rust-perf", Name: "Rust Performance", Kind: models.BehaviorKindDirective,
+			When:      map[string]interface{}{"language": "rust", "task": "performance"},
+			Canonical: "Rust performance optimization",
+		},
+	}
+
+	// Edges so spreading from go-security can reach go-general.
+	edges := []simulation.EdgeSpec{
+		{Source: "go-security", Target: "go-general", Kind: "semantic", Weight: 0.8},
+		{Source: "always-lint", Target: "go-general", Kind: "semantic", Weight: 0.5},
+	}
+
+	sessions := []simulation.SessionContext{
+		// Session 0: Go + security → matches go-security (spec=2), go-general (spec=1), always-lint (spec=0)
+		{ContextSnapshot: models.ContextSnapshot{FileLanguage: "go", Task: "security"}, Label: "go-security"},
+		// Session 1: Go + refactor → matches go-general (spec=1), always-lint (spec=0); NOT go-security
+		{ContextSnapshot: models.ContextSnapshot{FileLanguage: "go", Task: "refactor"}, Label: "go-refactor"},
+		// Session 2: Python + review → matches python-style (spec=1), always-lint (spec=0)
+		{ContextSnapshot: models.ContextSnapshot{FileLanguage: "python", Task: "review"}, Label: "python-review"},
+		// Session 3: CI + deploy → matches ci-deploy (spec=2), always-lint (spec=0)
+		{ContextSnapshot: models.ContextSnapshot{Environment: "ci", Task: "deploy"}, Label: "ci-deploy"},
+		// Session 4: Rust + performance → matches rust-perf (spec=2), always-lint (spec=0)
+		{ContextSnapshot: models.ContextSnapshot{FileLanguage: "rust", Task: "performance"}, Label: "rust-perf"},
+		// Session 5: Repeat of session 0 for Hebbian reinforcement
+		{ContextSnapshot: models.ContextSnapshot{FileLanguage: "go", Task: "security"}, Label: "go-security-repeat"},
+	}
+
+	// Use default spread config — inhibition enabled, normal propagation.
+	// Disable Hebbian to isolate seed selection behavior.
+	scenario := simulation.Scenario{
+		Name:           "seed-selection-integration",
+		Behaviors:      behaviors,
+		Edges:          edges,
+		Sessions:       sessions,
+		HebbianEnabled: false,
+		// SeedOverride: nil — uses real Pipeline.Run() path
+	}
+
+	result := r.Run(scenario)
+
+	// Log all session results for debugging.
+	for _, sr := range result.Sessions {
+		t.Logf("%s", simulation.FormatSessionDebug(sr))
+	}
+
+	// --- Session 0: Go + security ---
+	// go-security (spec=2, act=0.6) and go-general (spec=1, act=0.4) should both be seeds.
+	// always-lint (spec=0, act=0.3) should also be a seed.
+	s0 := result.Sessions[0]
+	simulation.AssertBehaviorIsSeed(t, s0, "go-security")
+	simulation.AssertBehaviorIsSeed(t, s0, "go-general")
+	simulation.AssertBehaviorIsSeed(t, s0, "always-lint")
+	// go-security should have higher activation than go-general (0.6 > 0.4 pre-sigmoid).
+	assertActivationHigher(t, s0, "go-security", "go-general")
+
+	// --- Session 1: Go + refactor ---
+	// go-general should be a seed, go-security should NOT be (task != "security").
+	s1 := result.Sessions[1]
+	simulation.AssertBehaviorIsSeed(t, s1, "go-general")
+	simulation.AssertBehaviorIsSeed(t, s1, "always-lint")
+	assertNotSeed(t, s1, "go-security")
+
+	// --- Session 2: Python + review ---
+	// python-style should be a seed; Go behaviors should not be seeds.
+	s2 := result.Sessions[2]
+	simulation.AssertBehaviorIsSeed(t, s2, "python-style")
+	simulation.AssertBehaviorIsSeed(t, s2, "always-lint")
+	// go-security may appear via spreading (always-lint → go-general → go-security)
+	// but should NOT be a seed.
+	assertNotSeed(t, s2, "go-security")
+	// go-general shouldn't be a seed (wrong language)
+	assertNotSeed(t, s2, "go-general")
+
+	// --- Session 3: CI + deploy ---
+	// ci-deploy (spec=2) should be a seed; language-specific behaviors should not be seeds.
+	s3 := result.Sessions[3]
+	simulation.AssertBehaviorIsSeed(t, s3, "ci-deploy")
+	simulation.AssertBehaviorIsSeed(t, s3, "always-lint")
+	assertNotSeed(t, s3, "go-security")
+	assertNotSeed(t, s3, "go-general")
+	assertNotSeed(t, s3, "python-style")
+
+	// --- Session 4: Rust + performance ---
+	// rust-perf (spec=2) should be a seed.
+	s4 := result.Sessions[4]
+	simulation.AssertBehaviorIsSeed(t, s4, "rust-perf")
+	simulation.AssertBehaviorIsSeed(t, s4, "always-lint")
+	assertNotSeed(t, s4, "go-security")
+
+	// --- Session 5: Repeat of session 0 ---
+	// Same as session 0: go-security and go-general should be seeds.
+	s5 := result.Sessions[5]
+	simulation.AssertBehaviorIsSeed(t, s5, "go-security")
+	simulation.AssertBehaviorIsSeed(t, s5, "go-general")
+
+	// --- Cross-session assertions ---
+	// always-lint should appear in every session (always-active).
+	for i, sr := range result.Sessions {
+		found := false
+		for _, r := range sr.Results {
+			if r.BehaviorID == "always-lint" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("always-lint not present in session %d", i)
+		}
+	}
+
+	// rust-perf should only appear as a seed in session 4.
+	simulation.AssertBehaviorIsSeed(t, result.Sessions[4], "rust-perf")
+	for _, i := range []int{0, 1, 2, 3, 5} {
+		assertNotSeed(t, result.Sessions[i], "rust-perf")
+	}
+
+	// All sessions should produce results.
+	simulation.AssertResultsNotEmpty(t, result)
+}
+
+// assertActivationHigher asserts that behaviorA has higher activation than
+// behaviorB in the given session.
+func assertActivationHigher(t *testing.T, sr simulation.SessionResult, higherID, lowerID string) {
+	t.Helper()
+	var higherAct, lowerAct float64
+	var foundHigher, foundLower bool
+	for _, r := range sr.Results {
+		if r.BehaviorID == higherID {
+			higherAct = r.Activation
+			foundHigher = true
+		}
+		if r.BehaviorID == lowerID {
+			lowerAct = r.Activation
+			foundLower = true
+		}
+	}
+	if !foundHigher {
+		t.Errorf("session %d: %s not found in results", sr.Index, higherID)
+		return
+	}
+	if !foundLower {
+		t.Errorf("session %d: %s not found in results", sr.Index, lowerID)
+		return
+	}
+	if higherAct <= lowerAct {
+		t.Errorf("session %d: expected %s (%.4f) > %s (%.4f)", sr.Index, higherID, higherAct, lowerID, lowerAct)
+	}
+}
+
+// assertNotSeed asserts that a behavior is NOT a seed (distance != 0 or absent)
+// in the given session.
+func assertNotSeed(t *testing.T, sr simulation.SessionResult, behaviorID string) {
+	t.Helper()
+	for _, r := range sr.Results {
+		if r.BehaviorID == behaviorID && r.Distance == 0 {
+			t.Errorf("session %d: behavior %s unexpectedly is a seed (distance=0, activation=%.4f)", sr.Index, behaviorID, r.Activation)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **Seed selection test** — exercises real `Pipeline.Run()` path (no `SeedOverride`), validates context matching and specificity-to-activation mapping across 6 behaviors and 6 sessions
- **Lateral inhibition test** — validates winner/loser separation with default production config (Strength=0.15, Breadth=7), confirms cliff at boundary and loser equalization
- **Creation gate test** — validates edges aren't created until `CreationGate=3` threshold is met, with co-activation counting added to `Runner.applyHebbian()`
- **New assertion helpers** — `AssertBehaviorIsSeed`, `AssertInhibitionGap`, `AssertEdgeAbsentAtSession`, `AssertEdgePresentAtSession`, `AssertBehaviorNotInResults`

Beads: `feedback-loop-ugi`, `feedback-loop-r3e`, `feedback-loop-72a`

## Test plan
- [x] `go test -v -count=1 ./internal/simulation/...` — all 11 tests pass (8 existing + 3 new)
- [x] `go test ./...` — full suite passes, no regressions
- [x] `go fmt ./...` — clean
- [x] Existing `TestCreationGateViability` (gate=1) still passes with runner modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)