### PR TITLE
fix: address focus mode review findings from #103

### DIFF
--- a/internal/visualization/templates/graph.html.tmpl
+++ b/internal/visualization/templates/graph.html.tmpl
@@ -319,6 +319,13 @@
     return 0.08;
   }
 
+  // Replace the alpha channel in an rgba() color string
+  function withAlpha(rgbaStr, alpha) {
+    return rgbaStr.replace(/,\s*[\d.]+\)$/, ',' + alpha + ')');
+  }
+
+  // adjacencyMap stays in sync with the graph because filterByScope is the
+  // only path that changes links, and it rebuilds adjacencyMap afterwards.
   var adjacencyMap = buildAdjacencyMap(validEdges);
 
   // Build degree map for node sizing
@@ -391,9 +398,7 @@
         ctx.stroke();
       }
 
-      // Reset alpha for labels (keep readable)
-      ctx.globalAlpha = 1.0;
-
+      // Match label opacity to node (dimmed labels on dimmed nodes)
       // Labels appear when zoomed in
       if (globalScale > 5) {
         var label = node.name || node.id;
@@ -405,6 +410,9 @@
         ctx.fillStyle = 'rgba(205,214,244,0.7)';
         ctx.fillText(label, node.x, node.y + r + 2);
       }
+
+      // Reset alpha so it doesn't leak into the next node's draw
+      ctx.globalAlpha = 1.0;
     })
     .nodePointerAreaPaint(function(node, color, ctx) {
       var r = Math.sqrt(node.val || 1) * 2.5;
@@ -418,10 +426,7 @@
     .linkColor(function(l) {
       var base = edgeColors[l.kind] || defaultEdgeColor;
       var lo = getLinkOpacity(l);
-      if (lo !== null) {
-        return base.replace(/[\d.]+\)$/, lo + ')');
-      }
-      return base;
+      return lo !== null ? withAlpha(base, lo) : base;
     })
     .linkWidth(function(l) {
       var w = edgeWidth[l.kind] || 1;
@@ -434,10 +439,7 @@
     .linkDirectionalArrowColor(function(l) {
       var base = 'rgba(147,153,178,0.6)';
       var lo = getLinkOpacity(l);
-      if (lo !== null) {
-        return base.replace(/[\d.]+\)$/, lo + ')');
-      }
-      return base;
+      return lo !== null ? withAlpha(base, lo) : base;
     })
     .d3AlphaDecay(0.02)
     .d3VelocityDecay(0.4)
@@ -472,9 +474,7 @@
     .onBackgroundClick(function() {
       // Ignore if a node was just clicked (force-graph fires both events)
       if (graph.__nodeClickTime && Date.now() - graph.__nodeClickTime < 200) return;
-      focusedNodeId = null;
-      focusDistances = null;
-      closePanel();
+      closePanel(); // also clears focus state
     })
     .onEngineStop(function() {
       // Auto-fit once when simulation first settles, capped at zoom=1
@@ -636,6 +636,8 @@
 
   window.closePanel = function() {
     panel.classList.remove('open');
+    focusedNodeId = null;
+    focusDistances = null;
   };
 
   function section(label, value) {
@@ -659,13 +661,19 @@
     return { focusedNodeId: focusedNodeId, distances: focusDistances };
   };
   window.__setFocusNode = function(nodeId) {
+    var gd = graph.graphData();
+    var found = gd.nodes.some(function(n) { return n.id === nodeId; });
+    if (!found) return false;
     focusedNodeId = nodeId;
     focusDistances = calculateFocusDistances(nodeId, adjacencyMap);
-    return !!focusDistances;
+    return true;
   };
   window.__clearFocus = function() {
     focusedNodeId = null;
     focusDistances = null;
+  };
+  window.__getNodeOpacity = function(nodeId) {
+    return getNodeOpacity(nodeId);
   };
 })();
 </script>

--- a/scripts/test-focus.js
+++ b/scripts/test-focus.js
@@ -50,13 +50,27 @@ async function testFocus() {
     const progResult = await page.evaluate(() => {
       const g = window.__graph;
       const nodes = g.graphData().nodes;
+      const links = g.graphData().links;
       if (nodes.length === 0) return { error: "no nodes" };
 
-      // Pick a node that has connections (find one with neighbors)
-      const nodeId = nodes[0].id;
+      // Find a node that has at least one connection for meaningful BFS
+      const connectedIds = new Set();
+      links.forEach((l) => {
+        connectedIds.add(l.source.id || l.source);
+        connectedIds.add(l.target.id || l.target);
+      });
+      const connectedNode = nodes.find((n) => connectedIds.has(n.id));
+      const nodeId = connectedNode ? connectedNode.id : nodes[0].id;
+
       const ok = window.__setFocusNode(nodeId);
       const state = window.__getFocusState();
-      return { nodeId, ok, state, nodeCount: nodes.length };
+      return {
+        nodeId,
+        ok,
+        state,
+        nodeCount: nodes.length,
+        hasConnections: !!connectedNode,
+      };
     });
 
     assert(!progResult.error, "graph has nodes");
@@ -77,6 +91,7 @@ async function testFocus() {
       const state = window.__getFocusState();
       const g = window.__graph;
       const links = g.graphData().links;
+      const nodes = g.graphData().nodes;
       const focusId = state.focusedNodeId;
 
       // Find direct neighbors
@@ -100,10 +115,15 @@ async function testFocus() {
         distCounts[d] = (distCounts[d] || 0) + 1;
       }
 
-      return { neighbors: neighborDistances, distCounts, totalReachable: Object.keys(state.distances).length };
+      return {
+        neighbors: neighborDistances,
+        distCounts,
+        totalReachable: Object.keys(state.distances).length,
+        totalNodes: nodes.length,
+      };
     });
 
-    console.log(`  Reachable nodes: ${bfsCheck.totalReachable}`);
+    console.log(`  Reachable nodes: ${bfsCheck.totalReachable}/${bfsCheck.totalNodes}`);
     console.log(`  Distance distribution: ${JSON.stringify(bfsCheck.distCounts)}`);
 
     const allNeighborsDist1 = bfsCheck.neighbors.every((n) => n.distance === 1);
@@ -111,6 +131,47 @@ async function testFocus() {
       bfsCheck.neighbors.length === 0 || allNeighborsDist1,
       `all direct neighbors have distance 1 (${bfsCheck.neighbors.length} neighbors)`
     );
+    assert(
+      bfsCheck.totalReachable <= bfsCheck.totalNodes,
+      `reachable (${bfsCheck.totalReachable}) <= total (${bfsCheck.totalNodes})`
+    );
+
+    // --- Test 3b: Opacity values for different distances ---
+    console.log("\n=== Test 3b: Opacity values ===");
+    const opacityCheck = await page.evaluate(() => {
+      const state = window.__getFocusState();
+      const g = window.__graph;
+      const nodes = g.graphData().nodes;
+
+      const focusedOpacity = window.__getNodeOpacity(state.focusedNodeId);
+
+      // Find a node at distance 1, 2, and unreachable
+      let d1Node = null, d2Node = null, unreachableNode = null;
+      for (const n of nodes) {
+        const d = state.distances[n.id];
+        if (d === 1 && !d1Node) d1Node = n.id;
+        if (d === 2 && !d2Node) d2Node = n.id;
+        if (d === undefined && !unreachableNode) unreachableNode = n.id;
+      }
+
+      return {
+        focusedOpacity,
+        d1Opacity: d1Node ? window.__getNodeOpacity(d1Node) : null,
+        d2Opacity: d2Node ? window.__getNodeOpacity(d2Node) : null,
+        unreachableOpacity: unreachableNode ? window.__getNodeOpacity(unreachableNode) : null,
+      };
+    });
+
+    assert(opacityCheck.focusedOpacity === 1.0, "focused node opacity is 1.0");
+    if (opacityCheck.d1Opacity !== null) {
+      assert(opacityCheck.d1Opacity === 1.0, "distance-1 node opacity is 1.0");
+    }
+    if (opacityCheck.d2Opacity !== null) {
+      assert(opacityCheck.d2Opacity === 0.4, "distance-2 node opacity is 0.4");
+    }
+    if (opacityCheck.unreachableOpacity !== null) {
+      assert(opacityCheck.unreachableOpacity === 0.12, "unreachable node opacity is 0.12");
+    }
 
     await page.screenshot({ path: "/tmp/focus-test-programmatic.png" });
 
@@ -122,6 +183,13 @@ async function testFocus() {
     });
     assert(clearResult.focusedNodeId === null, "focusedNodeId is null after clear");
     assert(clearResult.distances === null, "distances is null after clear");
+
+    // Verify opacity returns to 1.0 when no focus
+    const noFocusOpacity = await page.evaluate(() => {
+      const nodes = window.__graph.graphData().nodes;
+      return window.__getNodeOpacity(nodes[0].id);
+    });
+    assert(noFocusOpacity === 1.0, "all nodes opacity 1.0 when no focus");
 
     // --- Test 5: Click node via screen coords ---
     console.log("\n=== Test 5: Click node via screen coords ===");
@@ -169,7 +237,103 @@ async function testFocus() {
 
     await page.screenshot({ path: "/tmp/focus-test-cleared.png" });
 
-    // Console logs
+    // --- Test 7: closePanel clears focus state ---
+    console.log("\n=== Test 7: Panel close clears focus ===");
+    // Set focus programmatically, then call closePanel
+    const panelTest = await page.evaluate(() => {
+      const nodes = window.__graph.graphData().nodes;
+      window.__setFocusNode(nodes[0].id);
+      const before = window.__getFocusState();
+      window.closePanel();
+      const after = window.__getFocusState();
+      return {
+        beforeFocused: before.focusedNodeId !== null,
+        afterFocused: after.focusedNodeId,
+        afterDistances: after.distances,
+      };
+    });
+    assert(panelTest.beforeFocused, "focus was active before closePanel");
+    assert(panelTest.afterFocused === null, "closePanel clears focusedNodeId");
+    assert(panelTest.afterDistances === null, "closePanel clears distances");
+
+    // --- Test 7b: Re-focus switches to different node ---
+    console.log("\n=== Test 7b: Re-focus switches node ===");
+    const refocusTest = await page.evaluate(() => {
+      const nodes = window.__graph.graphData().nodes;
+      if (nodes.length < 2) return { skip: true };
+      const idA = nodes[0].id;
+      const idB = nodes[1].id;
+      window.__setFocusNode(idA);
+      const stateA = window.__getFocusState();
+      window.__setFocusNode(idB);
+      const stateB = window.__getFocusState();
+      return {
+        skip: false,
+        idA,
+        idB,
+        focusedA: stateA.focusedNodeId,
+        distA_A: stateA.distances[idA],
+        focusedB: stateB.focusedNodeId,
+        distB_B: stateB.distances[idB],
+        distB_A: stateB.distances[idA], // A's distance from B
+      };
+    });
+    if (!refocusTest.skip) {
+      assert(refocusTest.focusedA === refocusTest.idA, "first focus is on node A");
+      assert(refocusTest.distA_A === 0, "node A has distance 0 when focused");
+      assert(refocusTest.focusedB === refocusTest.idB, "re-focus switches to node B");
+      assert(refocusTest.distB_B === 0, "node B has distance 0 when focused");
+      assert(refocusTest.focusedB !== refocusTest.focusedA, "focus actually changed nodes");
+    }
+
+    // Clean up for next test
+    await page.evaluate(() => window.__clearFocus());
+
+    // --- Test 8: __setFocusNode rejects invalid node IDs ---
+    console.log("\n=== Test 8: Invalid node ID rejection ===");
+    const invalidResult = await page.evaluate(() => {
+      window.__clearFocus();
+      const ok = window.__setFocusNode("nonexistent-node-id");
+      const state = window.__getFocusState();
+      return { ok, state };
+    });
+    assert(invalidResult.ok === false, "__setFocusNode returns false for invalid ID");
+    assert(invalidResult.state.focusedNodeId === null, "focus not set for invalid node");
+    assert(invalidResult.state.distances === null, "distances not set for invalid node");
+
+    // --- Test 9: Scope filter clears focus ---
+    console.log("\n=== Test 9: Scope filter clears focus ===");
+    const scopeTest = await page.evaluate(() => {
+      const nodes = window.__graph.graphData().nodes;
+      window.__setFocusNode(nodes[0].id);
+      const beforeScope = window.__getFocusState();
+
+      // Click the "Local" scope button
+      const btn = document.querySelector('#scope-filter button[data-scope="local"]');
+      if (btn) btn.click();
+
+      const afterScope = window.__getFocusState();
+      return {
+        beforeFocused: beforeScope.focusedNodeId !== null,
+        afterFocused: afterScope.focusedNodeId,
+        afterDistances: afterScope.distances,
+      };
+    });
+    assert(scopeTest.beforeFocused, "focus was active before scope change");
+    assert(scopeTest.afterFocused === null, "scope change clears focusedNodeId");
+    assert(scopeTest.afterDistances === null, "scope change clears distances");
+
+    // Reset scope to "all" for clean state
+    await page.evaluate(() => {
+      const btn = document.querySelector('#scope-filter button[data-scope="all"]');
+      if (btn) btn.click();
+    });
+
+    // --- Final: Check for console errors ---
+    console.log("\n=== Console error check ===");
+    const errors = logs.filter((l) => l.startsWith("[ERROR]") || l.startsWith("[error]"));
+    assert(errors.length === 0, `no console errors (got ${errors.length})`);
+
     if (logs.length > 0) {
       console.log("\n=== CONSOLE LOGS ===");
       logs.forEach((l) => console.log("  " + l));


### PR DESCRIPTION
## Summary
Addresses all valid findings from Greptile's review of #103 (2/5 confidence) plus a deep self-review.

**Bugs fixed:**
- `closePanel()` now clears focus state — previously clicking the panel X button closed the panel but left the graph in dimmed focus mode with no way to unfocus except clicking background
- `__setFocusNode` validates node ID exists — previously passing a bogus ID would dim the entire graph to 0.12 opacity with no way to recover
- Label opacity now matches node opacity — previously a nearly invisible node (0.12) would have a fully opaque label when zoomed in

**Robustness:**
- Regex for alpha swap in rgba strings anchored after last comma (`/,\s*[\d.]+\)$/` instead of `/[\d.]+\)$/`) for safer matching
- Added `adjacencyMap` invariant comment documenting why it stays in sync

**Test improvements (15 -> 31 assertions):**
- Opacity value verification (`__getNodeOpacity` helper exposed)
- Panel close clears focus (Test 7)
- Invalid node ID rejection (Test 8)
- Scope filter clears focus (Test 9)
- Console error assertion (catches JS errors that would otherwise pass silently)
- Programmatic focus now picks a connected node for meaningful BFS coverage

**Note:** The floop data deletion from #103 (`.floop/edges.jsonl` emptied) was already resolved on main via #106. This PR only touches the template and test file.

## Test plan
- [x] `make graph-html` builds
- [x] `test-drag.js` regression: PASS
- [x] `test-focus.js` (31 assertions): PASS
- [x] Go visualization tests: PASS
- [ ] Manual browser check: click node, verify fade + glow, click X button to verify focus clears, change scope filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)