### PR TITLE
fix: add write permissions to auto-release job

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -60,6 +60,8 @@ jobs:
     name: Auto Patch Release
     needs: check-skip
     if: needs.check-skip.outputs.should_release == 'true'
+    permissions:
+      contents: write
     uses: ./.github/workflows/version-bump.yml
     with:
       bump: patch


### PR DESCRIPTION
Fixes workflow validation error where the release job couldn't call version-bump.yml due to insufficient permissions.

The reusable workflow needs \`contents: write\` to push tags, but the calling workflow only had \`contents: read\` at the top level. Adding explicit permissions to the release job resolves this.