### PR TITLE
fix: resolve auto-release concurrency deadlock + add CI gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & Discussion
-    url: https://github.com/nvandessel/feedback-loop/discussions
+    url: https://github.com/nvandessel/floop/discussions
     about: Ask questions and discuss ideas

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -8,11 +8,13 @@ on:
       - "docs/**"
       - ".beads/**"
       - ".floop/**"
+      - ".github/**"
       - "LICENSE"
 
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 concurrency:
   group: release
@@ -23,7 +25,7 @@ jobs:
     name: Check Skip Conditions
     runs-on: ubuntu-latest
     outputs:
-      should_release: ${{ steps.check.outputs.should_release }}
+      should_release: ${{ steps.ci-gate.outputs.should_release }}
     steps:
       - name: Check skip conditions
         id: check
@@ -55,6 +57,47 @@ jobs:
           fi
 
           echo "should_release=true" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for CI to pass
+        id: ci-gate
+        timeout-minutes: 30
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHOULD_RELEASE: ${{ steps.check.outputs.should_release }}
+        run: |
+          # Pass through skip decisions from previous step
+          if [ "$SHOULD_RELEASE" != "true" ]; then
+            echo "should_release=$SHOULD_RELEASE" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Waiting for CI workflow on commit ${{ github.sha }}..."
+
+          # Find the CI run for this commit (may take a moment to start)
+          for i in 1 2 3 4 5; do
+            RUN_ID=$(gh run list --workflow=ci.yml --commit="${{ github.sha }}" \
+              --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)
+            if [ -n "$RUN_ID" ]; then
+              break
+            fi
+            echo "CI run not found yet, waiting 10s... (attempt $i/5)"
+            sleep 10
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "No CI run found for this commit — CI may have been skipped by paths-ignore"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found CI run $RUN_ID, waiting for completion..."
+          if gh run watch "$RUN_ID" --exit-status; then
+            echo "CI passed — proceeding with release"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "CI failed — skipping release"
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
 
   release:
     name: Auto Patch Release

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -18,10 +18,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: release
-  cancel-in-progress: false
-
 permissions:
   contents: write
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-# GoReleaser configuration for feedback-loop
+# GoReleaser configuration for floop
 # Documentation: https://goreleaser.com
 
 version: 2
@@ -70,12 +70,12 @@ changelog:
 release:
   github:
     owner: nvandessel
-    name: feedback-loop
+    name: floop
   draft: false
   prerelease: auto
   mode: replace
   header: |
-    ## feedback-loop {{ .Tag }}
+    ## floop {{ .Tag }}
 
     Release artifacts for version {{ .Tag }}.
   footer: |
@@ -83,7 +83,7 @@ release:
 
     Download the appropriate archive for your platform, extract it, and move the `floop` binary to your PATH.
 
-    **Full changelog**: https://github.com/nvandessel/feedback-loop/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full changelog**: https://github.com/nvandessel/floop/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 # Disable features we're not using yet
 dockers: []

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -14,7 +14,9 @@ For minor or major releases, maintainers trigger the version-bump workflow manua
 
 ## Auto-Release
 
-Every push to `main` that changes code files triggers `auto-release.yml`. Documentation-only changes (`.md`, `docs/`, `.beads/`, `.floop/`, `LICENSE`) are ignored via `paths-ignore`.
+Every push to `main` that changes code files triggers `auto-release.yml`. Documentation-only changes (`.md`, `docs/`, `.beads/`, `.floop/`, `LICENSE`) and workflow changes (`.github/`) are ignored via `paths-ignore`.
+
+Before releasing, auto-release waits for the CI workflow to complete on the same commit. If CI fails, the release is skipped. If no CI run is found (e.g., the commit only touched paths ignored by CI), the release proceeds.
 
 ### Skip Mechanisms
 
@@ -256,8 +258,8 @@ gh pr create --base main --title "fix: critical bug" --body "Emergency hotfix fo
 **Purpose:** Automatically release patches when code merges
 
 **Jobs:**
-1. `check-skip` — Evaluate skip conditions (bot actor, commit message, PR label)
-2. `release` — If not skipped, call `version-bump.yml` with `bump: patch`
+1. `check-skip` — Evaluate skip conditions (bot actor, commit message, PR label), then wait for CI to pass
+2. `release` — If not skipped and CI passed, call `version-bump.yml` with `bump: patch`
 
 ### version-bump.yml
 


### PR DESCRIPTION
## Summary

- **Fix deadlock**: Remove `concurrency: group: release` from `version-bump.yml`. When called as a reusable workflow from `auto-release.yml`, both workflows declaring the same concurrency group causes GitHub to cancel the run with a deadlock error. The caller's concurrency block already serializes releases.
- **Add CI gate**: Auto-release now waits for the CI workflow to pass on the same commit before publishing. If CI fails, the release is skipped.
- **Exclude `.github/**`**: Workflow file changes no longer trigger auto-releases.

## Test plan

- [ ] Push a code change to main — auto-release waits for CI, then creates tag and publishes
- [ ] Manually trigger `version-bump.yml` via `workflow_dispatch` — works without concurrency issues
- [ ] Push a doc-only change — neither CI nor auto-release triggers
- [ ] Push a `.github/` change — CI triggers but auto-release does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)