### PR TITLE
feat: partial when-matching for activation pipeline

### DIFF
--- a/internal/activation/evaluate.go
+++ b/internal/activation/evaluate.go
@@ -1,7 +1,9 @@
 package activation
 
 import (
+	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/nvandessel/feedback-loop/internal/models"
 )
@@ -10,11 +12,24 @@ import (
 type ActivationResult struct {
 	Behavior models.Behavior
 
-	// MatchedConditions shows which 'when' conditions matched
+	// MatchedConditions shows which 'when' conditions were confirmed
 	MatchedConditions map[string]interface{}
 
-	// Specificity indicates how specific the match is (more conditions = higher)
+	// Specificity indicates how specific the match is (number of confirmed conditions)
 	Specificity int
+
+	// MatchScore is the ratio of confirmed conditions to total conditions (0.0-1.0).
+	// A score of 0.0 means all conditions were absent; 1.0 means all confirmed.
+	MatchScore float64
+}
+
+// MatchResult captures the outcome of evaluating a behavior's when-conditions.
+type MatchResult struct {
+	Matched      bool                   // true if no contradictions
+	Score        float64                // confirmed / total (0.0-1.0), 0 if no conditions
+	Confirmed    map[string]interface{} // conditions that matched
+	Absent       []string               // conditions where context had no value
+	Contradicted []string               // conditions where context value differed
 }
 
 // Evaluator determines which behaviors are active for a given context
@@ -25,17 +40,21 @@ func NewEvaluator() *Evaluator {
 	return &Evaluator{}
 }
 
-// Evaluate checks which behaviors match the given context
-// Returns behaviors that match, sorted by specificity (most specific first)
+// Evaluate checks which behaviors match the given context.
+// A behavior matches if none of its conditions are contradicted.
+// Absent conditions (context has no value for the key) are neutral.
+// Returns behaviors that match, sorted by specificity (most specific first).
 func (e *Evaluator) Evaluate(ctx models.ContextSnapshot, behaviors []models.Behavior) []ActivationResult {
 	var results []ActivationResult
 
 	for _, b := range behaviors {
-		if matches, matchedConditions := e.matchesBehavior(ctx, b); matches {
+		mr := e.evaluateMatch(ctx, b)
+		if mr.Matched {
 			results = append(results, ActivationResult{
 				Behavior:          b,
-				MatchedConditions: matchedConditions,
-				Specificity:       len(matchedConditions),
+				MatchedConditions: mr.Confirmed,
+				Specificity:       len(mr.Confirmed),
+				MatchScore:        mr.Score,
 			})
 		}
 	}
@@ -46,19 +65,48 @@ func (e *Evaluator) Evaluate(ctx models.ContextSnapshot, behaviors []models.Beha
 	return results
 }
 
-// matchesBehavior checks if a context matches a behavior's 'when' conditions
-func (e *Evaluator) matchesBehavior(ctx models.ContextSnapshot, b models.Behavior) (bool, map[string]interface{}) {
-	// Behaviors with no 'when' conditions always match
+// evaluateMatch checks a behavior's when-conditions against the context using
+// partial matching semantics:
+//   - Confirmed: context has the key and values match
+//   - Contradicted: context has the key but values differ (excludes behavior)
+//   - Absent: context doesn't have the key (neutral)
+func (e *Evaluator) evaluateMatch(ctx models.ContextSnapshot, b models.Behavior) MatchResult {
 	if len(b.When) == 0 {
-		return true, nil
+		return MatchResult{Matched: true, Score: 0.0, Confirmed: nil}
 	}
 
-	// Use the existing ContextSnapshot.Matches() method
-	if ctx.Matches(b.When) {
-		return true, b.When
+	confirmed := make(map[string]interface{})
+	var absent []string
+	var contradicted []string
+
+	for key, required := range b.When {
+		matched, hasValue := ctx.MatchField(key, required)
+		if hasValue && !matched {
+			contradicted = append(contradicted, key)
+		} else if hasValue && matched {
+			confirmed[key] = required
+		} else {
+			absent = append(absent, key)
+		}
 	}
 
-	return false, nil
+	if len(contradicted) > 0 {
+		return MatchResult{
+			Matched:      false,
+			Score:        0.0,
+			Confirmed:    confirmed,
+			Absent:       absent,
+			Contradicted: contradicted,
+		}
+	}
+
+	score := float64(len(confirmed)) / float64(len(b.When))
+	return MatchResult{
+		Matched:   true,
+		Score:     score,
+		Confirmed: confirmed,
+		Absent:    absent,
+	}
 }
 
 // sortBySpecificityAndPriority sorts results by specificity desc, then priority desc
@@ -71,10 +119,11 @@ func sortBySpecificityAndPriority(results []ActivationResult) {
 	})
 }
 
-// IsActive is a convenience method to check if a specific behavior is active
+// IsActive is a convenience method to check if a specific behavior is active.
+// A behavior is active if none of its conditions are contradicted by the context.
 func (e *Evaluator) IsActive(ctx models.ContextSnapshot, b models.Behavior) bool {
-	matches, _ := e.matchesBehavior(ctx, b)
-	return matches
+	mr := e.evaluateMatch(ctx, b)
+	return mr.Matched
 }
 
 // WhyActive explains why a behavior is or isn't active for a context
@@ -90,37 +139,54 @@ func (e *Evaluator) WhyActive(ctx models.ContextSnapshot, b models.Behavior) Act
 		return explanation
 	}
 
-	// Check each condition
+	// Reuse evaluateMatch for the core classification logic
+	mr := e.evaluateMatch(ctx, b)
+
+	// Build condition details from the match result
 	for key, required := range b.When {
 		conditionResult := ConditionResult{
 			Field:    key,
 			Required: required,
+			Actual:   ctx.GetField(key),
 		}
 
-		// Get actual value from context
-		conditionResult.Actual = ctx.GetField(key)
-		conditionResult.Matched = ctx.Matches(map[string]interface{}{key: required})
+		if _, ok := mr.Confirmed[key]; ok {
+			conditionResult.Status = "confirmed"
+			conditionResult.Matched = true
+		} else if sliceContains(mr.Contradicted, key) {
+			conditionResult.Status = "contradicted"
+			conditionResult.Matched = false
+		} else {
+			conditionResult.Status = "absent"
+			conditionResult.Matched = false
+		}
 
 		explanation.Conditions = append(explanation.Conditions, conditionResult)
 	}
 
-	// Behavior is active if all conditions matched
-	allMatched := true
-	for _, c := range explanation.Conditions {
-		if !c.Matched {
-			allMatched = false
-			break
-		}
-	}
-
-	explanation.IsActive = allMatched
-	if allMatched {
-		explanation.Reason = "All conditions matched"
+	// Behavior is active if no conditions are contradicted
+	explanation.IsActive = mr.Matched
+	if len(mr.Contradicted) > 0 {
+		sort.Strings(mr.Contradicted)
+		explanation.Reason = fmt.Sprintf("Contradicted on: %s", strings.Join(mr.Contradicted, ", "))
+	} else if len(mr.Absent) == 0 {
+		explanation.Reason = "All conditions confirmed"
 	} else {
-		explanation.Reason = "One or more conditions did not match"
+		explanation.Reason = fmt.Sprintf("Partially matched (%d/%d confirmed, %d absent)",
+			len(mr.Confirmed), len(b.When), len(mr.Absent))
 	}
 
 	return explanation
+}
+
+// sliceContains checks if a string slice contains a value.
+func sliceContains(s []string, v string) bool {
+	for _, item := range s {
+		if item == v {
+			return true
+		}
+	}
+	return false
 }
 
 // ActivationExplanation provides detailed info about why a behavior is/isn't active
@@ -137,4 +203,5 @@ type ConditionResult struct {
 	Required interface{} `json:"required"`
 	Actual   interface{} `json:"actual"`
 	Matched  bool        `json:"matched"`
+	Status   string      `json:"status"` // "confirmed", "contradicted", "absent"
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -54,6 +54,14 @@ const (
 	SimilarToUpperBound = 0.9
 )
 
+// Partial match constants control behavior matching with absent conditions.
+const (
+	// AbsentFloorActivation is the minimum seed activation for behaviors whose
+	// when-conditions are all absent (none confirmed, none contradicted).
+	// This ensures they still participate in spreading activation at low priority.
+	AbsentFloorActivation = 0.15
+)
+
 // Activation tier thresholds determine which injection tier a behavior receives
 // based on its spreading activation level.
 const (

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -813,7 +813,7 @@ func matchesToSeeds(matches []activation.ActivationResult) []spreading.Seed {
 	for i, m := range matches {
 		seeds[i] = spreading.Seed{
 			BehaviorID: m.Behavior.ID,
-			Activation: spreading.SpecificityToActivation(m.Specificity),
+			Activation: spreading.MatchScoreToActivation(len(m.Behavior.When), m.MatchScore),
 			Source:     spreading.BuildSourceLabel(m.MatchedConditions),
 		}
 	}
@@ -891,7 +891,7 @@ func buildSpreadIndex(seeds []spreading.Seed, matches []activation.ActivationRes
 	for _, m := range matches {
 		if _, ok := index[m.Behavior.ID]; !ok {
 			index[m.Behavior.ID] = spreadMeta{
-				activation: spreading.SpecificityToActivation(m.Specificity),
+				activation: spreading.MatchScoreToActivation(len(m.Behavior.When), m.MatchScore),
 				distance:   0,
 				seedSource: "direct",
 			}

--- a/internal/models/context.go
+++ b/internal/models/context.go
@@ -58,6 +58,19 @@ func (c *ContextSnapshot) Matches(predicate map[string]interface{}) bool {
 	return true
 }
 
+// MatchField checks a single when-condition against this context.
+// Returns:
+//   - matched=true, hasValue=true: context has the key and values match (confirmed)
+//   - matched=false, hasValue=true: context has the key but values differ (contradicted)
+//   - matched=false, hasValue=false: context doesn't have the key (absent)
+func (c *ContextSnapshot) MatchField(key string, required interface{}) (matched, hasValue bool) {
+	actual := c.GetField(key)
+	if actual == nil || actual == "" {
+		return false, false // absent
+	}
+	return matchValue(actual, required), true
+}
+
 // GetField retrieves a field value by name (exported for use by activation package)
 func (c *ContextSnapshot) GetField(key string) interface{} {
 	switch key {

--- a/internal/models/context_test.go
+++ b/internal/models/context_test.go
@@ -171,6 +171,86 @@ func TestContextSnapshot_Matches(t *testing.T) {
 	}
 }
 
+func TestContextSnapshot_MatchField(t *testing.T) {
+	tests := []struct {
+		name         string
+		ctx          ContextSnapshot
+		key          string
+		required     interface{}
+		wantMatched  bool
+		wantHasValue bool
+	}{
+		{
+			name:         "confirmed - language matches",
+			ctx:          ContextSnapshot{FileLanguage: "go"},
+			key:          "language",
+			required:     "go",
+			wantMatched:  true,
+			wantHasValue: true,
+		},
+		{
+			name:         "contradicted - language differs",
+			ctx:          ContextSnapshot{FileLanguage: "python"},
+			key:          "language",
+			required:     "go",
+			wantMatched:  false,
+			wantHasValue: true,
+		},
+		{
+			name:         "absent - no language set",
+			ctx:          ContextSnapshot{},
+			key:          "language",
+			required:     "go",
+			wantMatched:  false,
+			wantHasValue: false,
+		},
+		{
+			name:         "absent - empty string language",
+			ctx:          ContextSnapshot{FileLanguage: ""},
+			key:          "language",
+			required:     "go",
+			wantMatched:  false,
+			wantHasValue: false,
+		},
+		{
+			name:         "confirmed - task matches",
+			ctx:          ContextSnapshot{Task: "testing"},
+			key:          "task",
+			required:     "testing",
+			wantMatched:  true,
+			wantHasValue: true,
+		},
+		{
+			name:         "contradicted - task differs",
+			ctx:          ContextSnapshot{Task: "building"},
+			key:          "task",
+			required:     "testing",
+			wantMatched:  false,
+			wantHasValue: true,
+		},
+		{
+			name:         "absent - no task set",
+			ctx:          ContextSnapshot{},
+			key:          "task",
+			required:     "testing",
+			wantMatched:  false,
+			wantHasValue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, hasValue := tt.ctx.MatchField(tt.key, tt.required)
+			if matched != tt.wantMatched {
+				t.Errorf("matched = %v, want %v", matched, tt.wantMatched)
+			}
+			if hasValue != tt.wantHasValue {
+				t.Errorf("hasValue = %v, want %v", hasValue, tt.wantHasValue)
+			}
+		})
+	}
+}
+
 func TestInferLanguage(t *testing.T) {
 	tests := []struct {
 		filePath string

--- a/internal/simulation/seed_selection_test.go
+++ b/internal/simulation/seed_selection_test.go
@@ -128,13 +128,21 @@ func TestSeedSelectionIntegration(t *testing.T) {
 	assertNotSeed(t, s2, "go-general")
 
 	// --- Session 3: CI + deploy ---
-	// ci-deploy (spec=2) should be a seed; language-specific behaviors should not be seeds.
+	// ci-deploy (spec=2) should be a seed.
+	// With partial matching, go-general and python-style are also seeds because
+	// their language condition is absent (not contradicted). They get low activation
+	// via AbsentFloorActivation. go-security and rust-perf are excluded because
+	// their task condition is contradicted (deploy != security/performance).
 	s3 := result.Sessions[3]
 	simulation.AssertBehaviorIsSeed(t, s3, "ci-deploy")
 	simulation.AssertBehaviorIsSeed(t, s3, "always-lint")
+	simulation.AssertBehaviorIsSeed(t, s3, "go-general")
+	simulation.AssertBehaviorIsSeed(t, s3, "python-style")
 	assertNotSeed(t, s3, "go-security")
-	assertNotSeed(t, s3, "go-general")
-	assertNotSeed(t, s3, "python-style")
+	// ci-deploy should have higher activation than go-general/python-style
+	// since ci-deploy is fully confirmed (score=1.0) while they are all-absent (score=0.0).
+	assertActivationHigher(t, s3, "ci-deploy", "go-general")
+	assertActivationHigher(t, s3, "ci-deploy", "python-style")
 
 	// --- Session 4: Rust + performance ---
 	// rust-perf (spec=2) should be a seed.


### PR DESCRIPTION
## Summary
- Replace binary all-or-nothing when-matching with confirmed/contradicted/absent semantics
- Behaviors are only excluded when context actively contradicts a when-condition; absent conditions are neutral
- Add `MatchScoreToActivation` interpolation between `AbsentFloorActivation` (0.15) and full specificity activation
- Update `WhyActive` explanations to show per-condition status (confirmed/contradicted/absent)

## Details
Five Go lint behaviors with `when: {task: "development"}` were never activating because the old evaluator required ALL conditions to match. At session start, no `task` context exists, so they were excluded. With partial matching, absent conditions are neutral — behaviors participate at reduced activation proportional to their confirmed condition ratio.

**New types:** `MatchResult`, `MatchField` method on `ContextSnapshot`
**Changed:** `Evaluator.evaluateMatch()` replaces `matchesBehavior()`, `SelectSeeds` uses `MatchScoreToActivation`

## Test plan
- [x] `TestContextSnapshot_MatchField` — confirmed, contradicted, absent states
- [x] `TestEvaluator_PartialMatching` — full match, partial (absent task), contradiction, all absent, no-when
- [x] `TestMatchScoreToActivation` — score interpolation at various levels
- [x] Existing tests renamed/updated: `"contradiction excludes behavior"`, simulation seed tests
- [x] Full test suite passes: `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)