### PR TITLE
fix: pin Go toolchain to 1.25.7 to resolve stdlib TLS vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/nvandessel/feedback-loop
 
 go 1.25
 
+toolchain go1.25.7
+
 require (
 	github.com/modelcontextprotocol/go-sdk v1.3.0
 	github.com/spf13/cobra v1.10.2


### PR DESCRIPTION
## Summary

- Adds `toolchain go1.25.7` to `go.mod` to pin the Go version used by CI
- Resolves the `crypto/tls` stdlib vulnerability flagged by `govulncheck`
- The `go 1.25` directive alone resolves to whatever latest 1.25.x `setup-go` has cached, which may not include the TLS patch

## Test plan

- [x] `govulncheck ./...` — no vulnerabilities found
- [x] `go test ./...` — all 29 packages pass
- [ ] CI security job should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)