### PR TITLE
fix: persist co-activation counter for cross-session Hebbian learning

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -119,7 +119,7 @@ func NewServer(cfg *Config) (*Server, error) {
 		retentionPolicy:      retPolicy,
 		workerPool:           make(chan struct{}, maxBackgroundWorkers),
 		confirmedThisSession: make(map[string]struct{}),
-		coActivationTracker:  newCoActivationTracker(),
+		coActivationTracker:  initCoActivationTracker(graphStore),
 		hebbianConfig:        spreading.DefaultHebbianConfig(),
 		done:                 make(chan struct{}),
 	}

--- a/internal/store/multi.go
+++ b/internal/store/multi.go
@@ -285,6 +285,12 @@ func (m *MultiGraphStore) Traverse(ctx context.Context, start string, edgeKinds 
 	return nil, fmt.Errorf("start node not found in either store: %s", start)
 }
 
+// LocalStore returns the local (project-specific) store instance.
+// Used for project-scoped data like co-activation tracking.
+func (m *MultiGraphStore) LocalStore() GraphStore {
+	return m.localStore
+}
+
 // GlobalStore returns the global store instance for direct access.
 // This is used by the seeder to write seed behaviors to the global store.
 func (m *MultiGraphStore) GlobalStore() GraphStore {

--- a/internal/store/sqlite_coactivation.go
+++ b/internal/store/sqlite_coactivation.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// RecordCoActivation records a co-activation timestamp for a behavior pair.
+func (s *SQLiteGraphStore) RecordCoActivation(ctx context.Context, pairKey string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO co_activations (pair_key, activated_at) VALUES (?, ?)`,
+		pairKey, at.Format(time.RFC3339Nano))
+	if err != nil {
+		return fmt.Errorf("record co-activation: %w", err)
+	}
+	return nil
+}
+
+// GetCoActivations returns co-activation timestamps for a pair since the cutoff.
+func (s *SQLiteGraphStore) GetCoActivations(ctx context.Context, pairKey string, since time.Time) ([]time.Time, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT activated_at FROM co_activations WHERE pair_key = ? AND activated_at > ? ORDER BY activated_at`,
+		pairKey, since.Format(time.RFC3339Nano))
+	if err != nil {
+		return nil, fmt.Errorf("get co-activations: %w", err)
+	}
+	defer rows.Close()
+
+	var times []time.Time
+	for rows.Next() {
+		var ts string
+		if err := rows.Scan(&ts); err != nil {
+			return nil, fmt.Errorf("scan co-activation: %w", err)
+		}
+		t, err := time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			return nil, fmt.Errorf("parse co-activation time: %w", err)
+		}
+		times = append(times, t)
+	}
+	return times, nil
+}
+
+// PruneCoActivations removes entries older than the given cutoff. Returns count removed.
+func (s *SQLiteGraphStore) PruneCoActivations(ctx context.Context, before time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result, err := s.db.ExecContext(ctx,
+		`DELETE FROM co_activations WHERE activated_at < ?`,
+		before.Format(time.RFC3339Nano))
+	if err != nil {
+		return 0, fmt.Errorf("prune co-activations: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("prune co-activations rows affected: %w", err)
+	}
+	return int(n), nil
+}

--- a/internal/store/sqlite_coactivation_test.go
+++ b/internal/store/sqlite_coactivation_test.go
@@ -1,0 +1,128 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRecordCoActivation_Basic(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t)
+
+	now := time.Now()
+	err := s.RecordCoActivation(ctx, "a:b", now)
+	if err != nil {
+		t.Fatalf("RecordCoActivation failed: %v", err)
+	}
+
+	// Should be retrievable
+	times, err := s.GetCoActivations(ctx, "a:b", now.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("GetCoActivations failed: %v", err)
+	}
+	if len(times) != 1 {
+		t.Fatalf("expected 1 co-activation, got %d", len(times))
+	}
+}
+
+func TestRecordCoActivation_MultipleSamePair(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t)
+
+	now := time.Now()
+	for i := range 3 {
+		err := s.RecordCoActivation(ctx, "a:b", now.Add(time.Duration(i)*time.Second))
+		if err != nil {
+			t.Fatalf("RecordCoActivation %d failed: %v", i, err)
+		}
+	}
+
+	times, err := s.GetCoActivations(ctx, "a:b", now.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("GetCoActivations failed: %v", err)
+	}
+	if len(times) != 3 {
+		t.Fatalf("expected 3 co-activations, got %d", len(times))
+	}
+}
+
+func TestGetCoActivations_WindowFiltering(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t)
+
+	now := time.Now()
+	// Insert one old and one recent
+	err := s.RecordCoActivation(ctx, "a:b", now.Add(-2*time.Hour))
+	if err != nil {
+		t.Fatalf("RecordCoActivation (old) failed: %v", err)
+	}
+	err = s.RecordCoActivation(ctx, "a:b", now)
+	if err != nil {
+		t.Fatalf("RecordCoActivation (new) failed: %v", err)
+	}
+
+	// Query with 1-hour window — should only get the recent one
+	times, err := s.GetCoActivations(ctx, "a:b", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetCoActivations failed: %v", err)
+	}
+	if len(times) != 1 {
+		t.Fatalf("expected 1 co-activation within window, got %d", len(times))
+	}
+}
+
+func TestGetCoActivations_EmptyResult(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t)
+
+	times, err := s.GetCoActivations(ctx, "nonexistent:pair", time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetCoActivations failed: %v", err)
+	}
+	if len(times) != 0 {
+		t.Fatalf("expected 0 co-activations for unknown pair, got %d", len(times))
+	}
+}
+
+func TestPruneCoActivations_RemovesOld(t *testing.T) {
+	ctx := context.Background()
+	s := newTestSQLiteStore(t)
+
+	now := time.Now()
+	// Insert old and new entries
+	_ = s.RecordCoActivation(ctx, "a:b", now.Add(-48*time.Hour))
+	_ = s.RecordCoActivation(ctx, "a:b", now.Add(-25*time.Hour))
+	_ = s.RecordCoActivation(ctx, "a:b", now)
+	_ = s.RecordCoActivation(ctx, "c:d", now.Add(-48*time.Hour))
+
+	// Prune entries older than 24 hours
+	n, err := s.PruneCoActivations(ctx, now.Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("PruneCoActivations failed: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3 pruned, got %d", n)
+	}
+
+	// Only the recent one should remain
+	times, err := s.GetCoActivations(ctx, "a:b", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("GetCoActivations failed: %v", err)
+	}
+	if len(times) != 1 {
+		t.Errorf("expected 1 remaining co-activation, got %d", len(times))
+	}
+}
+
+// newTestSQLiteStore creates a SQLiteGraphStore backed by a temp directory for testing.
+func newTestSQLiteStore(t *testing.T) *SQLiteGraphStore {
+	t.Helper()
+	tmpDir := t.TempDir()
+	s, err := NewSQLiteGraphStore(tmpDir)
+	if err != nil {
+		t.Fatalf("NewSQLiteGraphStore: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -100,3 +100,16 @@ type ExtendedGraphStore interface {
 	// ValidateBehaviorGraph checks the graph for consistency issues.
 	ValidateBehaviorGraph(ctx context.Context) ([]ValidationError, error)
 }
+
+// CoActivationStore provides persistence for Hebbian co-activation tracking.
+// Implemented by SQLiteGraphStore. Used via type assertion from the MCP server.
+type CoActivationStore interface {
+	// RecordCoActivation records a co-activation timestamp for a behavior pair.
+	RecordCoActivation(ctx context.Context, pairKey string, at time.Time) error
+
+	// GetCoActivations returns co-activation timestamps for a pair since the cutoff.
+	GetCoActivations(ctx context.Context, pairKey string, since time.Time) ([]time.Time, error)
+
+	// PruneCoActivations removes entries older than the given cutoff. Returns count removed.
+	PruneCoActivations(ctx context.Context, before time.Time) (int, error)
+}


### PR DESCRIPTION
## Summary

- Adds `CoActivationStore` interface to `store.go` with 3 methods for persistent co-activation tracking
- Implements on `SQLiteGraphStore` in new `sqlite_coactivation.go`
- Schema **V5** migration: adds `co_activations` table (pair_key + activated_at, with index)
- Refactors `coActivationTracker` to use SQLite when available, in-memory fallback otherwise
- Adds `LocalStore()` accessor to `MultiGraphStore` (co-activation data is project-scoped)
- Wires persistent tracker automatically in `server.go` via `initCoActivationTracker()`

## Problem

The `coActivationTracker` was a `map[string][]time.Time` that reset on every MCP server restart. The `CreationGate` requires 3 co-occurrences within 7 days, but no data survived across sessions. Behaviors that co-activated once per session over 3 different days could never form edges.

## Schema note

This PR takes **V5**. If yzma PRs merge first and also need a version bump, one of us rebases. The migration uses `CREATE TABLE IF NOT EXISTS` so it's idempotent.

## Test plan

- [x] `TestRecordCoActivation_Basic` — insert and retrieve
- [x] `TestRecordCoActivation_MultipleSamePair` — multiple records for same pair
- [x] `TestGetCoActivations_WindowFiltering` — only returns entries within window
- [x] `TestGetCoActivations_EmptyResult` — no entries for unknown pair
- [x] `TestPruneCoActivations_RemovesOld` — prune entries older than cutoff
- [x] `TestCoActivationTracker_PersistentCrossSession` — **the key test**: gate accumulates across server restarts
- [x] `TestCoActivationTracker_PersistentFallback` — nil store uses in-memory path
- [x] All existing tests unchanged and passing (29 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)