### PR TITLE
fix: graph --serve works without --format html

### DIFF
--- a/cmd/floop/cmd_graph.go
+++ b/cmd/floop/cmd_graph.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"syscall"
 	"time"
 
 	"github.com/nvandessel/feedback-loop/internal/ranking"
@@ -33,6 +32,11 @@ func newGraphCmd() *cobra.Command {
 				return fmt.Errorf("open store: %w", err)
 			}
 			defer gs.Close()
+
+			// --serve implies HTML format
+			if serve {
+				format = string(visualization.FormatHTML)
+			}
 
 			ctx := context.Background()
 
@@ -127,7 +131,7 @@ func runGraphServer(cmd *cobra.Command, ctx context.Context, gs store.GraphStore
 
 	// Handle SIGINT/SIGTERM for graceful shutdown
 	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	notifySignals(sigCh)
 	defer signal.Stop(sigCh)
 
 	go func() {

--- a/cmd/floop/cmd_graph_test.go
+++ b/cmd/floop/cmd_graph_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGraphServeImpliesHTMLFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	isolateHome(t, tmpDir)
+
+	// Initialize floop store
+	rootCmd := newTestRootCmd()
+	rootCmd.AddCommand(newInitCmd())
+	rootCmd.SetArgs([]string{"init", "--root", tmpDir})
+	rootCmd.SetOut(&bytes.Buffer{})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Use io.Pipe so we can read server output without race conditions.
+	// If --serve is honored, the server blocks and writes "Graph server running at ...".
+	// If --serve is ignored, DOT text is printed and the command returns.
+	pr, pw := io.Pipe()
+
+	go func() {
+		rootCmd2 := newTestRootCmd()
+		rootCmd2.AddCommand(newGraphCmd())
+		rootCmd2.SetOut(pw)
+		rootCmd2.SetArgs([]string{"graph", "--serve", "--no-open", "--root", tmpDir})
+		rootCmd2.Execute()
+		pw.Close()
+	}()
+
+	// Read the first chunk of output. This blocks until the server writes
+	// its startup message or the command completes with DOT output.
+	type readResult struct {
+		data string
+		err  error
+	}
+	ch := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, 4096)
+		n, err := pr.Read(buf)
+		ch <- readResult{string(buf[:n]), err}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.err != nil && r.err != io.EOF {
+			t.Fatalf("read error: %v", r.err)
+		}
+		if strings.Contains(r.data, "digraph") {
+			t.Fatalf("--serve was ignored: got raw DOT output instead of starting server: %s", r.data)
+		}
+		if !strings.Contains(r.data, "Graph server running at") {
+			t.Fatalf("expected 'Graph server running at', got: %q", r.data)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for server output")
+	}
+
+	// Close the pipe reader to unblock the server goroutine.
+	pr.Close()
+}
+
+func TestGraphDefaultFormatIsDOT(t *testing.T) {
+	tmpDir := t.TempDir()
+	isolateHome(t, tmpDir)
+
+	// Initialize floop store
+	rootCmd := newTestRootCmd()
+	rootCmd.AddCommand(newInitCmd())
+	rootCmd.SetArgs([]string{"init", "--root", tmpDir})
+	rootCmd.SetOut(&bytes.Buffer{})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Run graph without --serve — should produce DOT output
+	rootCmd2 := newTestRootCmd()
+	rootCmd2.AddCommand(newGraphCmd())
+	var out bytes.Buffer
+	rootCmd2.SetOut(&out)
+	rootCmd2.SetArgs([]string{"graph", "--root", tmpDir})
+
+	if err := rootCmd2.Execute(); err != nil {
+		t.Fatalf("graph failed: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "digraph") {
+		t.Errorf("expected DOT output containing 'digraph', got: %s", output)
+	}
+}

--- a/cmd/floop/signal_unix.go
+++ b/cmd/floop/signal_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// notifySignals registers OS signal handlers for graceful shutdown.
+// On Unix systems, this includes both SIGINT and SIGTERM.
+func notifySignals(ch chan<- os.Signal) {
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+}

--- a/cmd/floop/signal_windows.go
+++ b/cmd/floop/signal_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+)
+
+// notifySignals registers OS signal handlers for graceful shutdown.
+// On Windows, only os.Interrupt (Ctrl+C) is supported; SIGTERM does not exist.
+func notifySignals(ch chan<- os.Signal) {
+	signal.Notify(ch, os.Interrupt)
+}


### PR DESCRIPTION
## Summary

- `floop graph --serve` now works without requiring `--format html` — the `--serve` flag implicitly sets the format to HTML
- Replaced direct `syscall.SIGTERM` usage with platform-separated `notifySignals()` helper (matching `internal/mcp/signal_*.go` pattern), eliminating dead code on Windows
- Added tests verifying `--serve` starts the server (not DOT output) and default format remains DOT

## Test plan

- [x] `go build ./cmd/floop` compiles
- [x] `GOOS=windows go build ./cmd/floop` cross-compiles for Windows
- [x] `go test ./cmd/floop/... -run TestGraph` — new tests pass
- [x] `go test ./...` — full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)