### PR TITLE
fix: auto-create .gitignore in .floop dir to prevent DB commits

### DIFF
--- a/.floop/.gitignore
+++ b/.floop/.gitignore
@@ -1,4 +1,7 @@
 # SQLite database files (source of truth is JSONL)
-*.db
-*.db-shm
-*.db-wal
+floop.db
+floop.db-shm
+floop.db-wal
+
+# Audit logs (runtime data, not version controlled)
+audit.jsonl

--- a/internal/store/paths.go
+++ b/internal/store/paths.go
@@ -38,3 +38,27 @@ func EnsureGlobalFloopDir() error {
 
 	return nil
 }
+
+// floopGitignore is the default .gitignore content for .floop directories.
+const floopGitignore = `# SQLite database files (source of truth is JSONL)
+floop.db
+floop.db-shm
+floop.db-wal
+
+# Audit logs (runtime data, not version controlled)
+audit.jsonl
+`
+
+// EnsureGitignore creates a .gitignore in the given .floop directory if one
+// does not already exist. This prevents accidentally committing database files
+// and runtime artifacts to version control.
+func EnsureGitignore(floopDir string) error {
+	gitignorePath := filepath.Join(floopDir, ".gitignore")
+	if _, err := os.Stat(gitignorePath); err == nil {
+		return nil // already exists, respect user customizations
+	}
+	if err := os.WriteFile(gitignorePath, []byte(floopGitignore), 0600); err != nil {
+		return fmt.Errorf("failed to create .gitignore: %w", err)
+	}
+	return nil
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -41,6 +41,11 @@ func NewSQLiteGraphStore(projectRoot string) (*SQLiteGraphStore, error) {
 		return nil, fmt.Errorf("failed to create .floop directory: %w", err)
 	}
 
+	// Ensure .gitignore exists to prevent committing DB files
+	if err := EnsureGitignore(floopDir); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
+	}
+
 	dbPath := filepath.Join(floopDir, "floop.db")
 	nodesFile := filepath.Join(floopDir, "nodes.jsonl")
 	edgesFile := filepath.Join(floopDir, "edges.jsonl")


### PR DESCRIPTION
When floop creates a project-scoped .floop directory, it now
automatically writes a .gitignore that excludes the SQLite database
files and audit.jsonl. Existing .gitignore files are left untouched
to respect user customizations.

Also updates the repo's .floop/.gitignore to cover audit.jsonl.

https://claude.ai/code/session_01HSFmmgYCXrSrG4A1pYTcUW