### PR TITLE
fix: use --version flag and resolve version from Go build info

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -46,7 +46,7 @@ jobs:
 
           # Test a Linux binary
           echo -e "\nTesting Linux amd64 binary..."
-          ./dist/floop_linux_amd64_v1/floop version
+          ./dist/floop_linux_amd64_v1/floop --version
 
       - name: Check archives
         run: |

--- a/cmd/floop/cmd_version.go
+++ b/cmd/floop/cmd_version.go
@@ -10,8 +10,9 @@ import (
 
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "version",
-		Short: "Print version information",
+		Use:    "version",
+		Short:  "Print version information",
+		Hidden: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			jsonOut, _ := cmd.Flags().GetBool("json")
 			if jsonOut {

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -14,6 +14,7 @@ These flags are available on every command.
 |------|------|---------|-------------|
 | `--json` | bool | `false` | Output as JSON (for agent consumption) |
 | `--root` | string | `.` | Project root directory |
+| `--version`, `-v` | bool | `false` | Print version information and exit |
 
 ---
 
@@ -140,25 +141,24 @@ floop reprocess --scope global
 
 ---
 
-### version
+### --version
 
 Print version information.
 
 ```
-floop version
+floop --version
+floop -v
 ```
-
-No command-specific flags.
 
 **Examples:**
 
 ```bash
-floop version
-# floop version 0.2.0-dev
-
-floop version --json
-# {"version":"0.2.0-dev"}
+floop --version
+# floop version v0.5.7 (commit: abc1234, built: 2026-02-10T15:30:00Z)
 ```
+
+> **Note:** `floop version` is still accepted for backward compatibility.
+> For JSON version output, use: `floop version --json`
 
 ---
 
@@ -1291,7 +1291,7 @@ floop help learn
 floop help completion bash
 ```
 
-**See also:** [version](#version)
+**See also:** [--version](#--version)
 
 ---
 
@@ -1327,5 +1327,5 @@ floop help completion bash
 | [tags](#tags) | Graph | Manage behavior tags |
 | [upgrade](#upgrade) | Core | Upgrade hook configuration to native Go subcommands |
 | [validate](#validate) | Management | Validate the behavior graph for consistency issues |
-| [version](#version) | Core | Print version information |
+| [--version](#--version) | Core | Print version information |
 | [why](#why) | Query | Explain why a behavior is or isn't active |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -106,7 +106,7 @@ gh release view v0.2.0
 # Download and test a binary
 gh release download v0.2.0 -p "floop-v0.2.0-linux-amd64.tar.gz"
 tar xzf floop-v0.2.0-linux-amd64.tar.gz
-./floop version
+./floop --version
 ```
 
 Expected output:
@@ -156,7 +156,7 @@ goreleaser build --snapshot --clean
 ls -lh dist/*/
 
 # Test version injection
-./dist/floop_linux_amd64_v1/floop version
+./dist/floop_linux_amd64_v1/floop --version
 
 # Test full release pipeline (doesn't publish)
 goreleaser release --snapshot --clean
@@ -170,7 +170,7 @@ rm -rf dist/
 All binaries include build metadata:
 
 ```bash
-./floop version
+./floop --version
 # Output: floop version v0.2.0 (commit: abc1234, built: 2026-02-10T15:30:00Z)
 
 ./floop version --json


### PR DESCRIPTION
The version subcommand showed "dev" with no commit data when installed
via "go install" because ldflags weren't set. Add runtime/debug.ReadBuildInfo()
fallback to populate version from Go module metadata. Also switch from
"floop version" subcommand to standard "floop --version" / "floop -v" flags.
The old subcommand is kept hidden for backward compatibility.

https://claude.ai/code/session_01XTL4r2SLDiztz9ZihzSsAk