### PR TITLE
docs: update documentation for vector index (v0.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ floop captures corrections you make to AI agents, extracts reusable behaviors, a
 - **Learns from corrections** — Tell the agent what it did wrong and what to do instead; floop turns that into a durable behavior
 - **Context-aware activation** — Behaviors fire based on file type, task, and semantic relevance — not a static prompt dump
 - **Spreading activation** — Graph-based memory retrieval inspired by cognitive science (Collins & Loftus, ACT-R) — triggered behaviors propagate energy to related nodes, pulling in associative context
+- **Vector-accelerated retrieval** — Local embeddings with a tiered vector index (brute-force → HNSW) pre-filter candidates before spreading activation, scaling to thousands of behaviors
 - **Token-optimized** — Budget-aware assembly keeps injected context within limits
 - **Store management** — Stats, deduplication, backup/restore, and graph visualization keep your behavior store healthy
 - **MCP server** — Works with any AI tool that supports the Model Context Protocol

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -2,7 +2,7 @@
 
 Complete reference for all floop commands. floop manages learned behaviors and conventions for AI coding agents -- it captures corrections, extracts reusable behaviors, and provides context-aware behavior activation for consistent agent operation.
 
-**Version:** 0.3.0
+**Version:** 0.8.0
 
 ---
 
@@ -212,6 +212,8 @@ floop active [flags]
 ```
 
 Lists all behaviors that are currently active based on the current context (file, task, language, etc.). Loads behaviors from both local and global stores.
+
+When local embeddings are configured, `floop active` uses vector similarity search as a pre-filter before applying spreading activation. The vector index automatically selects between brute-force (≤1,000 vectors) and HNSW (>1,000 vectors) backends for optimal performance. See [EMBEDDINGS.md](EMBEDDINGS.md) for details.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|

--- a/docs/FLOOP_USAGE.md
+++ b/docs/FLOOP_USAGE.md
@@ -232,10 +232,20 @@ This downloads two runtime dependencies (~130 MB total, cached in `~/.floop/`):
 ### How It Works
 
 1. **At learn-time:** New behaviors are embedded and stored alongside the behavior
-2. **At retrieval-time:** The current context (file, task, language) is embedded and compared against stored behavior embeddings using cosine similarity
-3. **Fallback:** When embeddings are unavailable, floop uses the standard predicate-matching pipeline
+2. **At startup:** Embeddings are loaded into an in-memory vector index for fast search
+3. **At retrieval-time:** The current context (file, task, language) is embedded and searched against the vector index
+4. **Fallback:** When embeddings are unavailable, floop uses the standard predicate-matching pipeline
 
 Behaviors without embeddings are always included in candidates — no behavior is silently dropped during migration.
+
+### Vector Index Tiers
+
+The vector index automatically selects the optimal backend based on your store size:
+
+- **≤1,000 behaviors** — Brute-force cosine similarity (exact, microsecond latency)
+- **>1,000 behaviors** — HNSW approximate nearest neighbor (O(log n), persisted to `.floop/hnsw.bin`)
+
+Promotion from brute-force to HNSW happens automatically — no configuration needed.
 
 For setup details, see [EMBEDDINGS.md](EMBEDDINGS.md). For the theory behind vector retrieval, see [SCIENCE.md](SCIENCE.md).
 

--- a/docs/GO_GUIDELINES.md
+++ b/docs/GO_GUIDELINES.md
@@ -1,6 +1,6 @@
 # Go Development Guidelines
 
-This guide outlines the coding standards for the feedback-loop project.
+This guide outlines the coding standards for the floop project.
 
 ## 1. Project Structure
 
@@ -152,6 +152,7 @@ func (c *ContextSnapshot) Matches(predicate map[string]any) bool { ... }
 - Current dependencies:
   - `github.com/spf13/cobra` - CLI framework
   - `gopkg.in/yaml.v3` - YAML parsing
+  - `github.com/coder/hnsw` - HNSW vector index (non-Windows only; see `//go:build` tags)
 
 ## 9. CLI Patterns (Cobra)
 

--- a/docs/SIMILARITY.md
+++ b/docs/SIMILARITY.md
@@ -20,9 +20,9 @@ When an LLM client implements the `EmbeddingComparer` interface, floop generates
 - Vectors are L2-normalized before comparison
 - Returns 0.0 for zero-magnitude or mismatched-length vectors
 
-The **local provider** (`llm.provider = local`) is designed to support offline embedding via GGUF models loaded through yzma. It is currently a stub — the interface exists but embedding generation is not yet functional. When it is ready, it will be the fastest tier in the chain.
+The **local provider** (`llm.provider = local`) runs offline embedding via GGUF models loaded through yzma (purego bindings to llama.cpp). It uses nomic-embed-text-v1.5 (Q4_K_M) to generate 768-dimension embeddings locally with no API keys or network access required. This is typically the fastest tier in the chain.
 
-Providers that support embeddings: `openai`, `ollama`, `local` (stub).
+Providers that support embeddings: `openai`, `ollama`, `local`.
 
 ## LLM Comparison
 
@@ -109,7 +109,7 @@ llm:
   comparison_model: claude-sonnet-4-5-20250929
   fallback_to_rules: true      # Fall back to Jaccard when LLM fails
 
-  # Local provider (stub — not yet functional)
+  # Local provider (offline embeddings via llama.cpp)
   local_lib_path: /path/to/yzma/libs
   local_model_path: /path/to/model.gguf
   local_embedding_model_path: /path/to/embedding-model.gguf

--- a/docs/integrations/mcp-server.md
+++ b/docs/integrations/mcp-server.md
@@ -79,7 +79,7 @@ Get active behaviors for the current context.
 }
 ```
 
-**Vector pre-filtering:** When local embeddings are configured (see [EMBEDDINGS.md](../EMBEDDINGS.md)), `floop_active` uses vector similarity search to pre-filter candidate behaviors before applying spreading activation. This finds semantically relevant behaviors even when their `when` predicates don't exactly match the current context. The system falls back to loading all behaviors when embeddings are unavailable.
+**Vector pre-filtering:** When local embeddings are configured (see [EMBEDDINGS.md](../EMBEDDINGS.md)), `floop_active` uses vector similarity search to pre-filter candidate behaviors before applying spreading activation. The vector index automatically selects between brute-force (≤1,000 behaviors) and HNSW (>1,000 behaviors) backends. This finds semantically relevant behaviors even when their `when` predicates don't exactly match the current context. The system falls back to loading all behaviors when embeddings are unavailable.
 
 **Example Response:**
 ```json


### PR DESCRIPTION
## Summary

- **EMBEDDINGS.md**: Add VectorIndex architecture section documenting BruteForce/HNSW tiered backends, platform notes for Windows fallback
- **SIMILARITY.md**: Remove stale "stub" notes — local embedding provider is now fully functional
- **CLI_REFERENCE.md**: Bump documented version from 0.3.0 to 0.8.0, add vector pre-filtering note to `floop active`
- **SCIENCE.md**: Add Vector Indexing Strategy subsection covering tiered auto-selection and shadow-map rebuild strategy
- **README.md**: Add "Vector-accelerated retrieval" to features list
- **FLOOP_USAGE.md**: Add Vector Index Tiers subsection explaining automatic backend selection
- **mcp-server.md**: Expand `floop_active` vector pre-filtering description with tier details
- **GO_GUIDELINES.md**: Fix project name (feedback-loop → floop), add `coder/hnsw` to dependency list

## Test plan

- [ ] All doc links resolve correctly
- [ ] No broken markdown rendering on GitHub
- [ ] Technical accuracy verified against implementation in `internal/vectorindex/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)