### PR TITLE
fix(security): bump Go to 1.26.2 to patch stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/nvandessel/floop
 
-go 1.26
-
-toolchain go1.26.1
+go 1.26.2
 
 require (
 	github.com/apache/arrow/go/v17 v17.0.0


### PR DESCRIPTION
## Summary
- Bumps Go language version in `go.mod` from 1.26 → 1.26.2 to unblock the Security CI job.
- Drops obsolete `toolchain` directive (patch version now lives in the `go` line).

## Vulnerabilities fixed
All 6 govulncheck findings are in the Go standard library and disappear with the 1.26.2 toolchain:

| ID | Area |
|---|---|
| GO-2026-4947 | crypto/x509 chain building |
| GO-2026-4946 | crypto/x509 policy validation |
| GO-2026-4870 | crypto/tls KeyUpdate DoS |
| GO-2026-4869 | archive/tar GNU sparse allocation |
| GO-2026-4866 | crypto/x509 name constraints auth bypass |
| GO-2026-4865 | html/template JsBraceDepth XSS |

(The 7th govulncheck finding is a non-called import and does not gate CI.)

## Test plan
- [x] `CGO_ENABLED=0 go build ./...`
- [x] `CGO_ENABLED=0 govulncheck ./...` → "No vulnerabilities found."
- [ ] CI Security job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)