### PR TITLE
refactor(hooks): slim session-start to learn directive only

### DIFF
--- a/cmd/floop/cmd_hook.go
+++ b/cmd/floop/cmd_hook.go
@@ -55,7 +55,7 @@ shell scripts, eliminating bash/jq dependencies for Windows support.`,
 }
 
 // newHookSessionStartCmd creates the 'hook session-start' subcommand.
-// It generates a prompt with all active behaviors for session injection.
+// It emits the floop learn directive for session injection.
 func newHookSessionStartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "session-start",
@@ -460,23 +460,6 @@ func detectTaskFromCommand(command string) string {
 	case strings.HasPrefix(command, "docker"),
 		strings.HasPrefix(command, "kubectl"):
 		return "deployment"
-	default:
-		return ""
-	}
-}
-
-// projectTypeToLanguage maps a ProjectType to its primary programming language.
-// Returns empty string for unknown project types.
-func projectTypeToLanguage(pt models.ProjectType) string {
-	switch pt {
-	case models.ProjectTypeGo:
-		return "go"
-	case models.ProjectTypePython:
-		return "python"
-	case models.ProjectTypeNode:
-		return "javascript"
-	case models.ProjectTypeRust:
-		return "rust"
 	default:
 		return ""
 	}

--- a/cmd/floop/cmd_hook.go
+++ b/cmd/floop/cmd_hook.go
@@ -10,9 +10,7 @@ import (
 	"time"
 
 	"github.com/nvandessel/floop/internal/activation"
-	"github.com/nvandessel/floop/internal/assembly"
 	"github.com/nvandessel/floop/internal/config"
-	"github.com/nvandessel/floop/internal/constants"
 	"github.com/nvandessel/floop/internal/learning"
 	"github.com/nvandessel/floop/internal/llm"
 	"github.com/nvandessel/floop/internal/models"
@@ -20,7 +18,6 @@ import (
 	"github.com/nvandessel/floop/internal/session"
 	"github.com/nvandessel/floop/internal/spreading"
 	"github.com/nvandessel/floop/internal/store"
-	"github.com/nvandessel/floop/internal/tiering"
 	"github.com/spf13/cobra"
 )
 
@@ -341,67 +338,17 @@ This applies to: explicit corrections, preferences, "don't do X", repeated feedb
 `
 }
 
-// runHookPrompt generates a markdown prompt with all active behaviors.
-// Used by session-start and first-prompt hooks.
+// runHookPrompt emits the floop learn directive at session start.
+// Behavior injection is handled entirely by the dynamic-context PreToolUse hook,
+// which uses spreading activation to surface relevant behaviors as the agent works.
+// This keeps the upfront token cost near zero.
 func runHookPrompt(cmd *cobra.Command, root string) error {
 	// Check initialization silently
 	if !floopDirExists(root) {
 		return nil
 	}
 
-	// Load config for token budget
-	cfg, err := config.Load()
-	if err != nil {
-		cfg = config.Default()
-	}
-	tokenBudget := cfg.TokenBudget.Default
-
-	// Load all behaviors from both scopes
-	behaviors, err := loadBehaviorsWithScope(root, constants.ScopeBoth)
-	if err != nil {
-		return nil // silent in hook context
-	}
-
-	if len(behaviors) == 0 {
-		// No behaviors to inject, but still output the learn directive
-		fmt.Fprint(cmd.OutOrStdout(), floopLearnDirective())
-		return nil
-	}
-
-	// Evaluate which behaviors are active (no specific context for session start)
-	ctxBuilder := activation.NewContextBuilder().
-		WithRepoRoot(root)
-
-	// Auto-infer language from project type at session start
-	if lang := projectTypeToLanguage(models.InferProjectType(root)); lang != "" {
-		ctxBuilder.WithLanguage(lang)
-	}
-
-	ctx := ctxBuilder.Build()
-
-	evaluator := activation.NewEvaluator()
-	matches := evaluator.Evaluate(ctx, behaviors)
-
-	resolver := activation.NewResolver()
-	resolved := resolver.Resolve(matches)
-
-	if len(resolved.Active) == 0 {
-		// No active behaviors, but still output the learn directive
-		fmt.Fprint(cmd.OutOrStdout(), floopLearnDirective())
-		return nil
-	}
-
-	// Use tiered injection with markdown format
-	results, behaviorMap := tiering.BehaviorsToResults(resolved.Active)
-	mapper := tiering.NewActivationTierMapper(tiering.DefaultActivationTierConfig())
-	plan := mapper.MapResults(results, behaviorMap, tokenBudget)
-
-	compiler := assembly.NewCompiler().
-		WithFormat(assembly.FormatMarkdown)
-	compiled := compiler.CompileTiered(plan)
-
-	output := compiled.Text + floopLearnDirective()
-	fmt.Fprint(cmd.OutOrStdout(), output)
+	fmt.Fprint(cmd.OutOrStdout(), floopLearnDirective())
 	return nil
 }
 

--- a/cmd/floop/cmd_hook_test.go
+++ b/cmd/floop/cmd_hook_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/nvandessel/floop/internal/llm"
-	"github.com/nvandessel/floop/internal/models"
 )
 
 // mockLLMClient is a test double for llm.Client that returns canned responses.
@@ -930,25 +929,3 @@ func TestRunDetectCorrection_PatternMiss(t *testing.T) {
 	}
 }
 
-// TestProjectTypeToLanguage verifies the mapping from project type to language.
-func TestProjectTypeToLanguage(t *testing.T) {
-	tests := []struct {
-		pt   models.ProjectType
-		want string
-	}{
-		{models.ProjectTypeGo, "go"},
-		{models.ProjectTypePython, "python"},
-		{models.ProjectTypeNode, "javascript"},
-		{models.ProjectTypeRust, "rust"},
-		{models.ProjectTypeUnknown, ""},
-	}
-
-	for _, tt := range tests {
-		t.Run(string(tt.pt), func(t *testing.T) {
-			got := projectTypeToLanguage(tt.pt)
-			if got != tt.want {
-				t.Errorf("projectTypeToLanguage(%v) = %q, want %q", tt.pt, got, tt.want)
-			}
-		})
-	}
-}

--- a/cmd/floop/cmd_hook_test.go
+++ b/cmd/floop/cmd_hook_test.go
@@ -928,4 +928,3 @@ func TestRunDetectCorrection_PatternMiss(t *testing.T) {
 		t.Errorf("expected pattern_miss in log, got: %s", logData)
 	}
 }
-


### PR DESCRIPTION
## Summary
- Remove full behavior dump from session-start and first-prompt hooks
- Session-start now emits only the floop learn directive (~67 tokens vs ~2,400 previously)
- Behavior injection relies entirely on dynamic-context PreToolUse hook, which uses spreading activation to surface relevant behaviors as the agent works

## Motivation
The upfront injection was dumping 100+ behaviors into context before the agent did anything — most irrelevant to the task at hand. The dynamic-context hook already handles contextual behavior surfacing via spreading activation seeded from tool inputs. This change removes the redundant upfront dump.

## Test plan
- [x] All existing hook tests pass (`TestHookSessionStart*`, `TestHookFirstPrompt*`)
- [x] `gofmt` clean
- [x] Verified `go run` output is learn directive only
- [ ] Manual: start a new session and confirm behaviors surface on first tool use via dynamic-context

🤖 Generated with [Claude Code](https://claude.com/claude-code)